### PR TITLE
Fix Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 
 deploy:
   provider: script
-  script: npm run deploy
+  script: node_modules/.bin/ts-node deploy.ts
   on:
     branch: master
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Hollowverse
 
+[![Build Status](https://travis-ci.org/hollowverse/hollowverse.svg?branch=master)](https://travis-ci.org/hollowverse/hollowverse)
 [![Greenkeeper badge](https://badges.greenkeeper.io/hollowverse/hollowverse.svg)](https://greenkeeper.io/)
 
 Politics, religions, and ideas.
 
-# Contributing
+## Contributing
 
 We're currently at the stage of heavy initial development. Any contributions are appreciated!
 Please submit an issue with you questions if you're not sure where to start.
@@ -28,12 +29,15 @@ This will provide a dev version of the front-end on `localhost:8080` and rebuild
 
 This will run the server straight from the source in `./server/src`. Nodemon will automatically refresh it on changes.
 
-### Building in production mode and deploying
+### Building in production mode
 
 * Build assets in production mode and run Firebase Hosting locally: `npm run server/firebase`
-* Deploy to Firebase: `npm run deploy` (You must have a `FIREBASE_TOKEN` environment variable set to the value obtained from running the command `firebase login:ci`)
 
-These commands are independent. It's not required to run anything before `npm run deploy`.
+This will build the JavaScript bundle in production mode and then execute `firebase serve`.
+
+## Deployment
+
+Deployment to Firebase happens automatically when a PR is merged to `master`.
 
 ## Built With
 

--- a/package.json
+++ b/package.json
@@ -9,12 +9,10 @@
     "client/build": "webpack --optimize-minimize --define process.env.NODE_ENV=\"'production'\" --config client/webpack.config.ts",
     "server/express": "nodemon --exec ts-node -- server/src/index.tsx",
     "server/firebase": "npm run client/build && firebase serve",
-    "deploy": "ts-node deploy.ts",
     "lint": "tslint '**/*.t{s,sx}' -e '**/node_modules/**' --fix",
     "precommit": "lint-staged",
     "test": "npm run client/build"
   },
-  "author": "Hollowverse",
   "license": "Unlicense",
   "homepage": "https://github.com/hollowverse/hollowverse#readme",
   "lint-staged": {


### PR DESCRIPTION
@deltaidea Travis CI is not executing the deploy command correctly. It seems that it's bypassing the `npm run` command and executing the content of the script directly, so it is [failing like so](https://travis-ci.org/hollowverse/hollowverse/builds/220738676#L1273).

I decided to remove `npm run deploy` (I don't think we should be running this manually anyway) and change the deployment command in `.travis.yml`.

I also changed `README.md` a bit, and added the Travis CI badge.