### PR TITLE
Implement circular-dependency-plugin with its custom type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
-typings/
 
 # Optional npm cache directory
 .npm

--- a/client/webpack.config.ts
+++ b/client/webpack.config.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as ExtractTextPlugin from 'extract-text-webpack-plugin'
+import * as CircularDependencyPlugin from 'circular-dependency-plugin'
 
 export default {
   entry: path.resolve(__dirname, 'src/webpackEntry.ts'),
@@ -49,6 +50,10 @@ export default {
       filename: 'css/styles.css',
       disable: false,
       allChunks: true,
+    }),
+    new CircularDependencyPlugin({
+      exclude: /a\.js|node_modules/,
+      failOnError: true,
     }),
   ],
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel-preset-es2015": "^6.24.1",
     "bulma": "^0.4.0",
     "chalk": "^1.1.3",
+    "circular-dependency-plugin": "^3.0.0",
     "classnames": "^2.2.3",
     "css-loader": "^0.28.0",
     "express": "^4.15.2",

--- a/typings/circular-dependency-plugin.d.ts
+++ b/typings/circular-dependency-plugin.d.ts
@@ -2,14 +2,15 @@ declare module 'circular-dependency-plugin' {
   import { Compiler, Plugin } from 'webpack'
 
   interface CircularDependencyPluginOptions {
-    exclude?: RegExp
+    exclude?: RegExp,
     failOnError?: boolean
   }
 
   class CircularDependencyPlugin implements Plugin {
-    constructor(options?: CircularDependencyPluginOptions);
+    constructor(options?: CircularDependencyPluginOptions)
     apply(compiler: Compiler): void
   }
+
   namespace CircularDependencyPlugin { }
 
   export = CircularDependencyPlugin

--- a/typings/circular-dependency-plugin.d.ts
+++ b/typings/circular-dependency-plugin.d.ts
@@ -2,7 +2,7 @@ declare module 'circular-dependency-plugin' {
   import { Compiler, Plugin } from 'webpack'
 
   interface CircularDependencyPluginOptions {
-    exclude?: RegExp,
+    exclude?: RegExp
     failOnError?: boolean
   }
 

--- a/typings/circular-dependency-plugin.d.ts
+++ b/typings/circular-dependency-plugin.d.ts
@@ -1,0 +1,16 @@
+declare module 'circular-dependency-plugin' {
+  import { Compiler, Plugin } from 'webpack'
+
+  interface CircularDependencyPluginOptions {
+    exclude?: RegExp
+    failOnError?: boolean
+  }
+
+  class CircularDependencyPlugin implements Plugin {
+    constructor(options?: CircularDependencyPluginOptions);
+    apply(compiler: Compiler): void
+  }
+  namespace CircularDependencyPlugin { }
+
+  export = CircularDependencyPlugin
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,6 +1148,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1:
   dependencies:
     inherits "^2.0.1"
 
+circular-dependency-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-3.0.0.tgz#9b68692e35b0e3510998d0164b6ae5011bea5760"
+
 cjson@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/cjson/-/cjson-0.3.3.tgz#a92d9c786e5bf9b930806329ee05d5d3261b4afa"
@@ -1643,13 +1647,13 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.3.3:
+debug@2.3.3, debug@^2.1.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1:
+debug@2.6.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -1664,12 +1668,6 @@ debug@2.6.3:
 debug@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
-  dependencies:
-    ms "0.7.3"
-
-debug@^2.1.1, debug@^2.2.0:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
   dependencies:
     ms "0.7.3"
 
@@ -3605,11 +3603,11 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
+ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@0.7.3, ms@^0.7.1:
+ms@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
 


### PR DESCRIPTION
Implements the circular-dependency-plugin with exluding node_modules
and fail on error mode. Also introduces a '/typings/' folder.

Closes #52 

Signed-off-by: Lev Esenish <lev.esenish@gmail.com>