### PR TITLE
Improve "Shadow Components"

### DIFF
--- a/client/src/pages/notablePerson/notablePerson.styles.ts
+++ b/client/src/pages/notablePerson/notablePerson.styles.ts
@@ -10,9 +10,10 @@ export const styles = StyleSheet.create({
     margin: '0.8rem 0.8rem',
   },
   notablePersonPhoto: {
+    background: shadesOfBlack[4],
     borderRadius: '50%',
-    margin: '0.7rem 0.25rem 0 0',
-    maxWidth: '80%',
+    margin: '0.7rem 0.5rem 0 0',
+    minWidth: '150px',
   },
   notablePersonText: {
     margin: '1.3rem 1rem 0 0',
@@ -30,7 +31,7 @@ export const styles = StyleSheet.create({
   notablePersonLabel: {
     alignItems: 'center',
     borderRadius: '30px',
-    background: 'linear-gradient(20deg, #ffb347 30%, #ffcc33 95%)',
+    background: 'linear-gradient(20deg, #ffb347 30%, #ffcc33 65%)',
     color: shadesOfBlack[1],
     display: 'inline-flex',
     fontSize: '.75rem',

--- a/client/src/pages/notablePerson/shadowComponent.styles.ts
+++ b/client/src/pages/notablePerson/shadowComponent.styles.ts
@@ -10,18 +10,20 @@ export const styles = StyleSheet.create({
   shadowPhoto: {
     background: shadesOfBlack[4],
     borderRadius: '50%',
-    height: '150px',
     minWidth: '150px',
+    minHeight: '100%',
+    margin: '0.7rem 0.5rem 0 0',
   },
   shadowLabels: {
     background: shadesOfBlack[4],
-    height: '1.1rem',
-    width: '6rem',
+    height: '1.3rem',
+    width: '5.5rem',
   },
   shadowName: {
     background: shadesOfBlack[4],
     borderRadius: '30px',
     height: '1.2rem',
+    marginBottom: '.9rem',
     marginTop: '1rem',
     width: '12rem',
   },
@@ -32,7 +34,7 @@ export const styles = StyleSheet.create({
   },
   shadowContent: {
     background: shadesOfBlack[4],
-    height: '0.75rem',
+    height: '0.70rem',
     marginLeft: '1rem',
     width: '90%',
   },
@@ -44,8 +46,28 @@ export const styles = StyleSheet.create({
     width: '80%',
   },
   shadowUsername: {
+    background: shadesOfBlack[6],
     marginTop: '1rem',
     height: '0.65rem',
     width: '13.5%',
   },
 })
+
+/* For future use.
+const mockAnimation = {
+  '0%': {
+    backgroundPosition: '-500px 0',
+  },
+  '100%': {
+    backgroundPosition: '500px 0',
+  },
+    mockAnimation: {
+    animationDuration: '2s',
+    animationIterationCount: 'infinite',
+    animationName: mockAnimation,
+    animationTimingFunction: 'linear',
+    background: 'linear-gradient(to right, #eeeeee 8%, #dddddd 18%, #eeeeee 33%)',
+    backgroundSize: '100%',
+  },
+}
+*/

--- a/client/src/pages/notablePerson/shadowComponent.tsx
+++ b/client/src/pages/notablePerson/shadowComponent.tsx
@@ -10,13 +10,13 @@ class ShadowComponentClass extends React.Component<{}, undefined> {
     return (
       <div className={css(common.page)}>
         <div className={css(npStyles.notablePersonTitleContainer, styles.shadowTopContainer)}>
-          <span className={css(styles.shadowPhoto)} />
+          <span className={css(styles.shadowPhoto)}/>
           <div className={css(npStyles.notablePersonText)}>
             <h1 className={css(npStyles.notablePersonTitle)}>Religion, politics, and ideas of...</h1>
-            <h1 className={css(common.titleTypography, npStyles.notablePersonName, styles.shadowName)} />
-            <span className={css(npStyles.notablePersonLabel, styles.shadowLabels)} />
-            <span className={css(npStyles.notablePersonLabel, styles.shadowLabels)} />
-            <span className={css(npStyles.notablePersonLabel, styles.shadowLabels)} />
+            <h1 className={css(common.titleTypography, npStyles.notablePersonName, styles.shadowName)}/>
+            <span className={css(npStyles.notablePersonLabel, styles.shadowLabels)}/>
+            <span className={css(npStyles.notablePersonLabel, styles.shadowLabels)}/>
+            <span className={css(npStyles.notablePersonLabel, styles.shadowLabels)}/>
           </div>
         </div>
         {this.renderShadowNotablePersonEvents([1, 2, 3])}
@@ -27,13 +27,13 @@ class ShadowComponentClass extends React.Component<{}, undefined> {
     return (
       n.map((f, i) =>
         <div key={i} className={css(eventStyles.eventContent, styles.shadowContainer)}>
-          <span className={css(npStyles.notablePersonLabel, styles.shadowContent)} />
-          <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowContentIndented)} />
-          <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowContentIndented)} />
-          <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowContentIndented)} />
+          <span className={css(npStyles.notablePersonLabel, styles.shadowContent)}/>
+          <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowContentIndented)}/>
+          <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowContentIndented)}/>
+          <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowContentIndented)}/>
           <div className={css(eventStyles.userContainer)}>
-            <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowUserComment)} />
-            <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowUsername)} />
+            <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowUserComment)}/>
+            <span className={css(npStyles.notablePersonLabel, styles.shadowContent, styles.shadowUsername)}/>
           </div>
         </div>,
       )


### PR DESCRIPTION
Checklist

- [x] No more displaying photos from placeholder images
- [x] Upload a certain sized profile photo for the mock NP (to FB storage)
- [x] Rearrange NP photo and it's shadows based on these changes. (Previously it was unpredictable due to placeholders being different every time.)

Future notes: 
The set size for profile photos might be achieved and optimized via cloud functions after user uploads a photo to the NP profile in future versions.

Result:
https://drive.google.com/open?id=0B8sgHUp1-h-ZeHd1QjVVaVdLVTA

Closes #100 