### PR TITLE
Fix runtime error with undefined reducer state

### DIFF
--- a/client/src/store/helpers.ts
+++ b/client/src/store/helpers.ts
@@ -86,14 +86,15 @@ export function isActionOfType<T extends ActionType>(
 
 /** Creates a reducer that handles a single action for an individual state entry.  */
 export function handleAction<
-  S extends object = StoreState,
+  K extends keyof S = keyof S,
+  S = StoreState,
   A extends ActionType = ActionType
->(actionType: A) {
-  return (state: S[keyof S], action: GenericAction): typeof state => {
+>(actionType: A, defaultState: S[K]) {
+  return (state: S[K], action: GenericAction) => {
     if (isActionOfType(action, actionType) && action.payload !== undefined) {
       return action.payload;
     }
 
-    return state;
+    return state || defaultState;
   };
 }

--- a/client/src/store/reducers.ts
+++ b/client/src/store/reducers.ts
@@ -4,19 +4,22 @@ import { handleAction } from 'store/helpers';
 import { combineReducers, Reducer as GenericReducer } from 'redux';
 
 const appReducers: ReducerMap<AppState> = {
-  displayWarning: handleAction('toggleWarning'),
-  userData: handleAction('setUserData'),
-  notablePerson: handleAction('setNotablePerson'),
-  createProfileUrlInputValue: handleAction('setCreateProfileUrlInputValue'),
-  lastSearchTerm: handleAction('setLastSearchTerm'),
-  isNavMenuOpen: handleAction('setIsNavMenuOpen'),
-  error: handleAction('setError'),
-  isLogoutPending: handleAction('setIsLogoutPending'),
-  isLoginPending: handleAction('setIsLoginPending'),
-  loginStatus: handleAction('setLoginStatus'),
-  isSearchPending: handleAction('setIsSearchPending'),
-  searchResults: handleAction('setSearchResults'),
-  searchInputValue: handleAction('setSearchInputValue'),
+  displayWarning: handleAction<'displayWarning'>('toggleWarning', false),
+  userData: handleAction<'userData'>('setUserData', null),
+  notablePerson: handleAction<'notablePerson'>('setNotablePerson', null),
+  createProfileUrlInputValue: handleAction<'createProfileUrlInputValue'>(
+    'setCreateProfileUrlInputValue',
+    '',
+  ),
+  lastSearchTerm: handleAction<'lastSearchTerm'>('setLastSearchTerm', ''),
+  isNavMenuOpen: handleAction<'isNavMenuOpen'>('setIsNavMenuOpen', false),
+  error: handleAction<'error'>('setError', null),
+  isLogoutPending: handleAction<'isLogoutPending'>('setIsLogoutPending', false),
+  isLoginPending: handleAction<'isLoginPending'>('setIsLoginPending', false),
+  loginStatus: handleAction<'loginStatus'>('setLoginStatus', 'unknown'),
+  isSearchPending: handleAction<'isSearchPending'>('setIsSearchPending', false),
+  searchResults: handleAction<'searchResults'>('setSearchResults', null),
+  searchInputValue: handleAction<'searchInputValue'>('setSearchInputValue', ''),
 };
 
 /**


### PR DESCRIPTION
* The new handleAction helper now requires passing the initial state of the state entry because Redux does not allow returning undefined from reducers
* To provide better type checking, the state key must be passed as a type parameter to handleAction until TS fixes https://github.com/Microsoft/TypeScript/issues/10717