### PR TITLE
Remove normalize CSS from global stylesheet

### DIFF
--- a/client/src/globalStyles.css
+++ b/client/src/globalStyles.css
@@ -1,97 +1,12 @@
 /* 
-  Contents
-    1- Normalize/Base Global Styles (will stay but change)
-    2- Old compiled output of SASS until the styles are replaced with JS (to be removed)
+  Contains old compiled output of SASS until the styles are replaced with JS (to be removed)
 */
 
-/* Normalize via minireset.css v0.0.3 | MIT License | github.com/jgthms/minireset.css */
-
-html,
-body,
-p,
-ol,
-ul,
-li,
-dl,
-dt,
-dd,
-blockquote,
-figure,
-fieldset,
-legend,
-textarea,
-pre,
-iframe,
-hr,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin: 0;
-  padding: 0;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: 100%;
-  font-weight: normal;
-}
-
-ul {
-  list-style: none;
-}
-
-button,
-input,
-select,
-textarea {
-  margin: 0;
-}
-
-html {
-  box-sizing: border-box;
-  text-rendering: optimizeLegibility;
-  line-height: 1.5;
-}
-
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
-
-img,
-embed,
-iframe,
-object,
-audio,
-video {
-  height: auto;
-  max-width: 100%;
-}
-
-iframe {
-  border: 0;
-}
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-td,
-th {
-  padding: 0;
-  text-align: left;
-}
-
 /* Hollowverse Globals */
+
+body, html {
+  margin: 0;
+}
 
 body,
 #app,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -197,7 +197,7 @@ const globalCssLoaders = [
   ...sassLoaders,
 ];
 
-const CssModuleLoaders = [
+const cssModuleLoaders = [
   {
     loader: 'typings-for-css-modules-loader',
     options: {
@@ -290,7 +290,7 @@ const config = {
         exclude: excludedPatterns,
         use: extractCssModules.extract({
           fallback: 'style-loader',
-          use: CssModuleLoaders,
+          use: cssModuleLoaders,
         }),
       },
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -190,7 +190,7 @@ const globalCssLoaders = [
   {
     loader: 'postcss-loader',
     options: {
-      plugins: [normalize(), autoprefixer()],
+      plugins: [normalize({ forceImport: true }), autoprefixer()],
       sourceMap: true,
     },
   },


### PR DESCRIPTION
We are using postcss-normalize which automatically adds a custom build of normalize.css based on the browsers we target (as specified in "browserslist" field in package.json)