### PR TITLE
Update resource limits and configure auto-scaling

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -13,6 +13,10 @@ skip_files:
   - client/.babelrc
   - .git
 
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 3
+
 resources:
-  cpu: 2
-  memory_gb: 2.3
+  cpu: 1
+  memory_gb: 0.3


### PR DESCRIPTION
This should lower our costs significantly. Using the [Google Cloud Platform Pricing Calculator](https://cloud.google.com/products/calculator/#id=7013ac3e-adde-40c3-a14f-709866a7b536), I estimate that this change should lower the cost of each instance of each version to $40.47/month approximately. With automatic scaling configured to allow a maximum of 3 instances per version, I expect that we should not go above $121 per version per month (this is the maximum, assuming increased load on our website).

I had to increase the resources previously to fix an out of memory error (https://github.com/forabi/hollowverse/commit/80cd71a126fa675a89edf5ea13317496977e36d1). I'm not sure why we are not getting the same error now with the memory set to as low as 0.3GB, but it may be due to an updated Node.js or Webpack version.

We should keep an eye on our response times with the new resource limits.