### PR TITLE
Enable cron in lets-encrypt service

### DIFF
--- a/letsEncrypt/Dockerfile
+++ b/letsEncrypt/Dockerfile
@@ -46,12 +46,10 @@ ADD . .
 # Schedule renewal using a cron job
 RUN crontab crontab-update-cert
 
-# 1) Start cron and at daemons to enable schedule tasks 
+# 1) Start cron and at daemons to enable scheduled tasks 
 #
 # 2) Schedule certificate generation 15 minutes from now to make sure
 # the service is deployed before running the command
 #
-# 3) Schedule cron jobs to renew the certificate
-#
-# 4) Serve public files to allow Let's Encrypt to verify domain ownership
+# 3) Serve public files to allow Let's Encrypt to verify domain ownership
 CMD cron start && atd && (echo 'node /cert.js' | at now + 15 minutes) && http-server ./public -p 8080

--- a/letsEncrypt/Dockerfile
+++ b/letsEncrypt/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get update && apt-get install -y certbot nodejs cron at google-cloud-sdk
 # Launch at daemon to run tasks scheduled using at
 RUN atd
 
+# Launch cron service to activate scheduled renewals
+RUN service cron start
+
 RUN npm install -g http-server
 
 # This directory will contain domain vertification files

--- a/letsEncrypt/Dockerfile
+++ b/letsEncrypt/Dockerfile
@@ -21,19 +21,16 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 RUN apt-get update && apt-get install -y certbot nodejs cron at google-cloud-sdk
 
-# Launch at daemon to run tasks scheduled using at
-RUN atd
-
-# Launch cron service to activate scheduled renewals
-RUN service cron start
-
 RUN npm install -g http-server
+
+# Add package.json so this layer can be cached independently
+ADD ./package.json .
+
+# Install dependencies for cert.js script
+RUN npm install
 
 # This directory will contain domain vertification files
 RUN mkdir -p ./public
-
-# Add the certificate genenration and update scripts and crontab file to the container
-ADD . .
 
 # Add service account key required to update the certificate
 #
@@ -43,15 +40,18 @@ ADD . .
 # the file does not exist
 ADD ./gae-client-secret.json .
 
-# Schedule certificate generation 30 minutes from now to make sure
-# the service is deployed before running the command
-RUN echo 'node /cert.js' | at now + 30 minutes
+# Add the certificate genenration and update scripts and crontab file to the container
+ADD . .
 
 # Schedule renewal using a cron job
 RUN crontab crontab-update-cert
 
-# Install dependencies for cert.js script
-RUN npm install
-
-# Serve public files to allow Let's Encrypt to verify domain ownership
-CMD http-server ./public -p 8080
+# 1) Start cron and at daemons to enable schedule tasks 
+#
+# 2) Schedule certificate generation 15 minutes from now to make sure
+# the service is deployed before running the command
+#
+# 3) Schedule cron jobs to renew the certificate
+#
+# 4) Serve public files to allow Let's Encrypt to verify domain ownership
+CMD cron start && atd && (echo 'node /cert.js' | at now + 15 minutes) && http-server ./public -p 8080


### PR DESCRIPTION
After installing `cron`, it will be enabled on next reboot. Since there is no such thing as "rebooting" in Docker container, we need to enable it manually in order to activate scheduled cron jobs.