### PR TITLE
Ignore static files based on pattern match

### DIFF
--- a/redirectionProxy/redirectionProxy.ts
+++ b/redirectionProxy/redirectionProxy.ts
@@ -26,10 +26,7 @@ const proxyServer = httpProxy.createProxyServer();
 proxyServer.on('proxyReq', (proxyReq: any) => {
   if (
     !(proxyReq.path as string).endsWith('/') &&
-    !(
-      (proxyReq.path as string).endsWith('.css') ||
-      (proxyReq.path as string).endsWith('.js')
-    )
+    !(proxyReq.path as string).match(/\/.+\.[a-z]{2,4}$/ig)
   ) {
     proxyReq.path = `${proxyReq.path}/`;
   }


### PR DESCRIPTION
I wrote a quick script to test various paths, and it seems to work for static files. (versioned assets work regardless of whether the path ends with `/` or not)

```
/wp-content/themes/hollowverse/style.css Should add "/"? false
/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1 Should add "/"? true
/wp-content/plugins/hollowverse/hollowverse.js?ver=4.1.18 Should add "/"? true
/wp-content/themes/twentyeleven/style.css Should add "/"? false
/wp-includes/js/comment-reply.min.js?ver=4.1.18 Should add "/"? true
/wp-content/themes/hollowverse/images/bright_squares.png Should add "/"? false
/wp-content/themes/hollowverse/images/transparent-black.png Should add "/"? false
/tom-hanks Should add "/"? true
/tom-hanks/ Should add "/"? false
/favicon.ico Should add "/"? false
```