### PR TITLE
Enable Strict Transport Security

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,6 +8,13 @@ import { logEndpoint } from './logger/logEndpoint';
 
 const server = express();
 
+const maxAge = 18000;
+
+server.post('/enable-https', (_, res) => {
+  res.setHeader('Strict-Transport-Security', `max-age=${maxAge}`);
+  res.status(201).send('Created');
+});
+
 // tslint:disable no-http-string
 const OLD_SERVER_ADDRESS =
   process.env.OLD_SERVER || 'http://dw5a6b9vjmt7w.cloudfront.net/';


### PR DESCRIPTION
According to [Google Cloud Platform documentation](https://cloud.google.com/appengine/docs/flexible/java/upgrading#appyaml_changes), the recommended way to redirect to HTTPS is to add [the `Strict-Transport-Security` header](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet) (HSTS) to all requests. When the browser receives a response with that header set, it will automatically load all subsequent requests on that domain via HTTPS, even if the URL of a link starts with `http://`.

This might be a little bit dangerous, because if for any reason our HTTPS set up fails, users won't be able to load any page **and they won't be able to visit the HTTP version**. This is why I propose enabling this header in incremental steps:

* We start with a small max age value: this value tells the browser when to check again if the HSTS configuration needs to be updated. Using a small value gives the users a chance to return to our HTTP version if SSL fails.
* We only enable HSTS if we `POST` to `/enable-https`. This reduces the chances that a regular user is redirected to HTTPS. We can tests the changes ourselves and decide what to do next.