### PR TITLE
Use HTTP Link header to preload static assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@types/autoprefixer": "^6.7.2",
     "@types/body-parser": "^1.16.4",
     "@types/domready": "^0.0.29",
-    "@types/express": "^4.0.36",
+    "@types/express": "^4.0.39",
     "@types/helmet": "^0.0.37",
     "@types/http-proxy": "^1.12.0",
     "@types/lodash": "^4.14.68",

--- a/src/app/server.tsx
+++ b/src/app/server.tsx
@@ -52,6 +52,7 @@ export const createServerRenderMiddleware = ({
       cssHash,
       scripts,
       stylesheets,
+      publicPath,
     } = flushChunks(clientStats, { chunkNames });
 
     logger.debug(`Request path: ${req.path}`);
@@ -59,6 +60,19 @@ export const createServerRenderMiddleware = ({
     logger.debug('Scripts served:', scripts);
     logger.debug('Stylesheets served:', stylesheets);
     logger.debug('icon stats:', iconStats);
+    logger.debug('Public path:', publicPath);
+
+    // Tell browsers to start fetching scripts and stylesheets as soon as they
+    // parse the HTTP headers of the page
+    res.setHeader(
+      'Link',
+      [
+        ...stylesheets.map(
+          link => `<${publicPath}/${link}>; rel=preload; as=style`,
+        ),
+        ...scripts.map(src => `<${publicPath}/${src}>; rel=preload; as=script`),
+      ].join(','),
+    );
 
     const icons = iconStats ? iconStats.html.join(' ') : '';
 

--- a/src/app/server.tsx
+++ b/src/app/server.tsx
@@ -68,7 +68,7 @@ export const createServerRenderMiddleware = ({
       'Link',
       [
         ...stylesheets.map(
-          link => `<${publicPath}/${link}>; rel=preload; as=style`,
+          src => `<${publicPath}/${src}>; rel=preload; as=style`,
         ),
         ...scripts.map(src => `<${publicPath}/${src}>; rel=preload; as=script`),
       ].join(','),

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,7 +35,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express@*", "@types/express@^4.0.36":
+"@types/express@*", "@types/express@^4.0.39":
   version "4.0.39"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.0.39.tgz#1441f21d52b33be8d4fa8a865c15a6a91cd0fa09"
   dependencies:


### PR DESCRIPTION
This should help browsers start fetching the resources required to render the page sooner.

Reference: https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header/

Note that this is not HTTP/2 server push (although the blog post linked above mentions that Cloudflare magically converts those hints to HTTP/2 pushes). This is equivalent to using `<link rel="preload" />` in HTML, but since the hints are in the HTTP headers, they are processed earlier.

In HTTP/2 server push, the server starts pushing the resources before the browser even asks for them. This might be wasteful if the browser already has those resources cached. Although the browser can ask the server to stop pushing the resources, the message may be delayed so the server could have finished pushing all the resources before it got the message to stop.