### PR TITLE
Fix publicPath for server bundle

### DIFF
--- a/src/webpack/webpack.config.server.js
+++ b/src/webpack/webpack.config.server.js
@@ -10,6 +10,7 @@ const {
   serverDistDirectory,
   excludedPatterns,
   cssModulesPattern,
+  publicPath,
 } = require('./variables');
 const { isProd } = require('./env');
 const {
@@ -28,6 +29,7 @@ const serverSpecificConfig = {
     filename: '[name].js',
     libraryTarget: 'commonjs2',
     path: serverDistDirectory,
+    publicPath,
   },
 
   // By default, webpack will consume and bundle all `require` calls.


### PR DESCRIPTION
Images were not being loaded correctly with JavaScript disabled because the `publicPath` (`/static/`) was not specified.