### PR TITLE
Allow /log to be handled by the new app server

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "APP_SERVER_PORT=${APP_SERVER_PORT:-3001} HOT=1 NODE_ENV=development node --inspect=9231 -r 'source-map-support/register' -r 'ts-node/register' src/appServer.ts",
     "server/app-server/start": "node dist/appServer.js",
     "server/main-server/dev":
-      "PORT=${PORT:-8081} nodemon -q --watch src --ignore src/app --ignore src/webpack --ext ts,tsx,json --exec 'node --inspect=0.0.0.0:${SERVER_DEBUG_PORT:-9231} -r 'ts-node/register' src/mainServer.ts'",
+      "PORT=${PORT:-8081} API_ENDPOINT=${API_ENDPOINT:-https://api.hollowverse.com/graphql} nodemon -q --watch src --ignore src/app --ignore src/webpack --ext ts,tsx,json --exec 'node --inspect=0.0.0.0:${SERVER_DEBUG_PORT:-9232} -r 'ts-node/register' src/mainServer.ts'",
     "remotedev": "remotedev --hostname=localhost --port=8000",
     "server/main-server/start": "node dist/mainServer.js",
     "server/build": "tsc --project ./src",

--- a/src/app/logger/logEndpoint.ts
+++ b/src/app/logger/logEndpoint.ts
@@ -4,7 +4,7 @@ import * as bodyParser from 'body-parser';
 import { isBodyValid } from './utils';
 import { log } from './logger';
 
-const logEndpoint = express();
+export const logEndpoint = express();
 
 /**
  * For compatibility with `navigator.sendBeacon`, we are accepting
@@ -50,5 +50,3 @@ logEndpoint.use([
     res.send({ error: 'Server Error' });
   },
 ]);
-
-export { logEndpoint };

--- a/src/mainServer.ts
+++ b/src/mainServer.ts
@@ -47,6 +47,9 @@ const newPaths = new Set(redirectionMap.values());
 // Examples: /static/app.js, /static/vendor.js => new hollowverse
 server.get('/static/*', appServer);
 
+// Allow the new app server to handle
+server.post('/log', appServer);
+
 // Because ":/path" matches routes on both new and old servers, the new proxy also has
 // to know the new app paths to avoid redirection loops.
 server.get('/:path', (req, res, next) => {

--- a/src/mainServer.ts
+++ b/src/mainServer.ts
@@ -47,7 +47,7 @@ const newPaths = new Set(redirectionMap.values());
 // Examples: /static/app.js, /static/vendor.js => new hollowverse
 server.get('/static/*', appServer);
 
-// Allow the new app server to handle
+// Allow the new app server to handle /log
 server.post('/log', appServer);
 
 // Because ":/path" matches routes on both new and old servers, the new proxy also has


### PR DESCRIPTION
#259 fixed the call to `sendLogs`, but we still need to allow `/log` to be handled by the new app instead of falling back to the old website.