### PR TITLE
Provide polyfills for Node.js with Webpack.ProvidePlugin

### DIFF
--- a/src/app/helpers/getUniversalUrl.ts
+++ b/src/app/helpers/getUniversalUrl.ts
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 /**
  * Unlike browsers, Node.js has no idea what the domain
  * of the server is, so all URLs must be absolute.

--- a/src/app/serverEntry.ts
+++ b/src/app/serverEntry.ts
@@ -1,20 +1,7 @@
 // This will be transformed via babel-preset-env to individual
 // polyfill requires as needed by targeted browsers
 import '@babel/polyfill';
-
-import { URL, URLSearchParams } from 'url';
 import { createServerRenderMiddleware } from 'server';
-import fetch from 'node-fetch';
-
-declare var global: NodeJS.Global & {
-  URL: typeof URL;
-  URLSearchParams: typeof URLSearchParams;
-  fetch: typeof fetch;
-};
-
-global.URL = URL;
-global.URLSearchParams = URLSearchParams;
-global.fetch = fetch;
 
 export { createServerRenderMiddleware } from './server';
 

--- a/src/webpack/webpack.config.server.js
+++ b/src/webpack/webpack.config.server.js
@@ -103,6 +103,12 @@ const serverSpecificConfig = {
     new webpack.DefinePlugin({
       __IS_SERVER__: true,
     }),
+
+    new webpack.ProvidePlugin({
+      URL: ['url', 'URL'],
+      URLSearchParams: ['url', 'URLSearchParams'],
+      fetch: ['node-fetch', 'default'],
+    }),
   ],
 };
 


### PR DESCRIPTION
Assigning variables to the `global` object was not working and I had to `import { URL } from 'url'` instead. This caused the Node.js implementation of the URL spec to be bundled in the browser build as well, which is not required as browsers natively support the spec.