### PR TITLE
Fix undefined htmlattributes

### DIFF
--- a/src/app/index.server.html
+++ b/src/app/index.server.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" ${htmlAttributes}>
+<html lang="en" dir="ltr">
   <head>
     ${title}
     ${meta}


### PR DESCRIPTION
This was causing parsing of the template to fail in production because Webpack was attempting to minify the template and converted `htmlAttributes` to lowercase, and when interpolating, lodash `template` expected `htmlAttributes` to be in camelCase.