### PR TITLE
Add preconnect Resource Hint for the API endpoint

### DIFF
--- a/src/app/components/App/App.tsx
+++ b/src/app/components/App/App.tsx
@@ -45,7 +45,7 @@ export const App = class extends React.Component<{}, State> {
             content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, shrink-to-fit=no"
           />
           <meta charSet="utf-8" />
-          <link rel="preconnect" href={__API_ENDPOINT__} />
+          <link rel="preconnect" href={__API_ENDPOINT__} crossOrigin="anonymous" />
         </Helmet>
         <Route>
           {props => {

--- a/src/app/components/App/App.tsx
+++ b/src/app/components/App/App.tsx
@@ -45,6 +45,7 @@ export const App = class extends React.Component<{}, State> {
             content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, shrink-to-fit=no"
           />
           <meta charSet="utf-8" />
+          <link rel="preconnect" href="https://api.hollowverse.com/graphql" />
         </Helmet>
         <Route>
           {props => {

--- a/src/app/components/App/App.tsx
+++ b/src/app/components/App/App.tsx
@@ -45,7 +45,7 @@ export const App = class extends React.Component<{}, State> {
             content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, shrink-to-fit=no"
           />
           <meta charSet="utf-8" />
-          <link rel="preconnect" href="https://api.hollowverse.com/graphql" />
+          <link rel="preconnect" href={__API_ENDPOINT__} />
         </Helmet>
         <Route>
           {props => {


### PR DESCRIPTION
From [Can I Use](https://caniuse.com/#feat=link-rel-preconnect):

> Gives a hint to the browser to begin the connection handshake (DNS, TCP, TLS) in the background to improve performance.

It's likely that the user would visit another NP page via "Other interesting profile" or search results, so this should help reduce the API query time.