### PR TITLE
Re-enable address bar bouncing behavior on Safari for iOS

### DIFF
--- a/src/app/components/App/App.global.scss
+++ b/src/app/components/App/App.global.scss
@@ -79,16 +79,3 @@ input[type='search'] {
   appearance: none;
 }
 /* #endregion Disable rounded corners of search fields on Safari for iOS */
-
-/* #region  Disable address bar bouncing behavior on Safari for iOS */
-html {
-  height: 100%;
-  overflow: hidden;
-}
-
-body {
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-}
-/* #endregion  Disable address bar bouncing behavior on Safari for iOS */


### PR DESCRIPTION
This is causing another issue with Safari, which causes the page to be stuck and prevents the user from scrolling down when the initial touch to start scrolling is located at the topmost part of the page until the touching finger is released ([as can be seen here](https://www.dropbox.com/s/hw8f7mjm6z3tu0g/File%2006-02-2018%2C%205%2033%2008%20PM.mov?dl=0))