### PR TITLE
Experiment with the new React context API

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
     "html-webpack-harddisk-plugin": "^0.1.0",
     "html-webpack-plugin": "^2.30.1",
     "http-proxy-middleware": "^0.17.4",
-    "husky": "^0.15.0-beta.16",
     "lint-staged": "^4.0.3",
     "lodash-es": "^4.17.4",
     "lodash-webpack-plugin": "^0.11.4",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "bluebird": "^3.5.1",
     "body-parser": "^1.17.2",
     "classcat": "^1.0.1",
+    "create-react-context": "^0.1.6",
     "date-fns": "^1.29.0",
     "dom-ready": "^1.0.6",
     "domready": "^1.0.8",

--- a/src/app/appDependenciesContext.ts
+++ b/src/app/appDependenciesContext.ts
@@ -8,7 +8,7 @@ export const defaultAppDependenciesContext = {
   loadAlgoliaModule: defaultLoadAlgoliaModule,
 };
 
-export type AppDependenciesContext = typeof defaultAppDependenciesContext;
+export type AppDependencies = typeof defaultAppDependenciesContext;
 export const AppDependenciesContext = createReactContext(
   defaultAppDependenciesContext,
 );

--- a/src/app/appDependenciesContext.ts
+++ b/src/app/appDependenciesContext.ts
@@ -9,6 +9,6 @@ export const defaultAppDependenciesContext = {
 };
 
 export type AppDependenciesContext = typeof defaultAppDependenciesContext;
-export const appDependenciesContext = createReactContext(
+export const AppDependenciesContext = createReactContext(
   defaultAppDependenciesContext,
 );

--- a/src/app/appDependenciesContext.ts
+++ b/src/app/appDependenciesContext.ts
@@ -1,0 +1,14 @@
+import createReactContext from 'create-react-context';
+import { client as defaultApiClient } from 'api/client';
+
+const defaultLoadAlgoliaModule = async () => import('vendor/algolia');
+
+export const defaultAppDependenciesContext = {
+  apiClient: defaultApiClient,
+  loadAlgoliaModule: defaultLoadAlgoliaModule,
+};
+
+export type AppDependenciesContext = typeof defaultAppDependenciesContext;
+export const AppDependenciesContext = createReactContext(
+  defaultAppDependenciesContext,
+);

--- a/src/app/appDependenciesContext.ts
+++ b/src/app/appDependenciesContext.ts
@@ -9,6 +9,6 @@ export const defaultAppDependenciesContext = {
 };
 
 export type AppDependenciesContext = typeof defaultAppDependenciesContext;
-export const AppDependenciesContext = createReactContext(
+export const appDependenciesContext = createReactContext(
   defaultAppDependenciesContext,
 );

--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -25,6 +25,7 @@ import { client as defaultApiContext } from 'api/client';
 const defaultAlgoliaContext = async () => import('vendor/algolia');
 
 export type AlgoliaContext = typeof defaultAlgoliaContext;
+export type ApiClientContext = typeof defaultApiContext;
 
 export const AlgoliaContext = createReactContext(defaultAlgoliaContext);
 export const ApiContext = createReactContext(defaultApiContext);

--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -4,7 +4,6 @@ import { ConnectedRouter as Router } from 'react-router-redux';
 import domready from 'domready';
 import { hydrate } from 'react-dom';
 import createBrowserHistory from 'history/createBrowserHistory';
-import createReactContext from 'create-react-context';
 
 import { App } from 'components/App/App';
 import { createConfiguredStore } from 'store/createConfiguredStore';
@@ -12,26 +11,16 @@ import { StoreState } from 'store/types';
 import { unhanldedErrorThrown } from 'store/features/logging/actions';
 import { loadIntersectionObserverPolyfill } from 'helpers/loadPolyfill';
 import { HelmetProvider } from 'react-helmet-async';
+import {
+  AppDependenciesContext,
+  defaultAppDependenciesContext,
+} from 'appDependenciesContext';
 
 declare const __INITIAL_STATE__: StoreState | undefined;
 
 const history = createBrowserHistory();
 
 const { store } = createConfiguredStore(history, __INITIAL_STATE__);
-
-import { client as defaultApiClient } from 'api/client';
-
-const defaultLoadAlgoliaModule = async () => import('vendor/algolia');
-
-const defaultAppDependenciesContext = {
-  apiClient: defaultApiClient,
-  loadAlgoliaModule: defaultLoadAlgoliaModule,
-};
-
-export type AppDependenciesContext = typeof defaultAppDependenciesContext;
-export const AppDependenciesContext = createReactContext(
-  defaultAppDependenciesContext,
-);
 
 const renderApp = (NewApp: typeof App = App) => {
   hydrate(

--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -18,14 +18,29 @@ const history = createBrowserHistory();
 
 const { store } = createConfiguredStore(history, __INITIAL_STATE__);
 
+import createReactContext from 'create-react-context';
+
+import { client as defaultApiContext } from 'api/client';
+
+const defaultAlgoliaContext = async () => import('vendor/algolia');
+
+export type AlgoliaContext = typeof defaultAlgoliaContext;
+
+export const AlgoliaContext = createReactContext(defaultAlgoliaContext);
+export const ApiContext = createReactContext(defaultApiContext);
+
 const renderApp = (NewApp: typeof App = App) => {
   hydrate(
     <HelmetProvider>
-      <Provider store={store}>
-        <Router history={history}>
-          <NewApp />
-        </Router>
-      </Provider>
+      <AlgoliaContext.Provider value={defaultAlgoliaContext}>
+        <ApiContext.Provider value={defaultApiContext}>
+          <Provider store={store}>
+            <Router history={history}>
+              <NewApp />
+            </Router>
+          </Provider>
+        </ApiContext.Provider>
+      </AlgoliaContext.Provider>
     </HelmetProvider>,
     // tslint:disable-next-line:no-non-null-assertion
     document.getElementById('app')!,

--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -4,6 +4,7 @@ import { ConnectedRouter as Router } from 'react-router-redux';
 import domready from 'domready';
 import { hydrate } from 'react-dom';
 import createBrowserHistory from 'history/createBrowserHistory';
+import createReactContext from 'create-react-context';
 
 import { App } from 'components/App/App';
 import { createConfiguredStore } from 'store/createConfiguredStore';
@@ -18,30 +19,30 @@ const history = createBrowserHistory();
 
 const { store } = createConfiguredStore(history, __INITIAL_STATE__);
 
-import createReactContext from 'create-react-context';
+import { client as defaultApiClient } from 'api/client';
 
-import { client as defaultApiContext } from 'api/client';
+const defaultLoadAlgoliaModule = async () => import('vendor/algolia');
 
-const defaultAlgoliaContext = async () => import('vendor/algolia');
+const defaultAppDependenciesContext = {
+  apiClient: defaultApiClient,
+  loadAlgoliaModule: defaultLoadAlgoliaModule,
+};
 
-export type AlgoliaContext = typeof defaultAlgoliaContext;
-export type ApiClientContext = typeof defaultApiContext;
-
-export const AlgoliaContext = createReactContext(defaultAlgoliaContext);
-export const ApiContext = createReactContext(defaultApiContext);
+export type AppDependenciesContext = typeof defaultAppDependenciesContext;
+export const AppDependenciesContext = createReactContext(
+  defaultAppDependenciesContext,
+);
 
 const renderApp = (NewApp: typeof App = App) => {
   hydrate(
     <HelmetProvider>
-      <AlgoliaContext.Provider value={defaultAlgoliaContext}>
-        <ApiContext.Provider value={defaultApiContext}>
-          <Provider store={store}>
-            <Router history={history}>
-              <NewApp />
-            </Router>
-          </Provider>
-        </ApiContext.Provider>
-      </AlgoliaContext.Provider>
+      <AppDependenciesContext.Provider value={defaultAppDependenciesContext}>
+        <Provider store={store}>
+          <Router history={history}>
+            <NewApp />
+          </Router>
+        </Provider>
+      </AppDependenciesContext.Provider>
     </HelmetProvider>,
     // tslint:disable-next-line:no-non-null-assertion
     document.getElementById('app')!,

--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -12,7 +12,7 @@ import { unhanldedErrorThrown } from 'store/features/logging/actions';
 import { loadIntersectionObserverPolyfill } from 'helpers/loadPolyfill';
 import { HelmetProvider } from 'react-helmet-async';
 import {
-  AppDependenciesContext,
+  appDependenciesContext,
   defaultAppDependenciesContext,
 } from 'appDependenciesContext';
 
@@ -25,13 +25,13 @@ const { store } = createConfiguredStore(history, __INITIAL_STATE__);
 const renderApp = (NewApp: typeof App = App) => {
   hydrate(
     <HelmetProvider>
-      <AppDependenciesContext.Provider value={defaultAppDependenciesContext}>
+      <appDependenciesContext.Provider value={defaultAppDependenciesContext}>
         <Provider store={store}>
           <Router history={history}>
             <NewApp />
           </Router>
         </Provider>
-      </AppDependenciesContext.Provider>
+      </appDependenciesContext.Provider>
     </HelmetProvider>,
     // tslint:disable-next-line:no-non-null-assertion
     document.getElementById('app')!,

--- a/src/app/client.tsx
+++ b/src/app/client.tsx
@@ -12,7 +12,7 @@ import { unhanldedErrorThrown } from 'store/features/logging/actions';
 import { loadIntersectionObserverPolyfill } from 'helpers/loadPolyfill';
 import { HelmetProvider } from 'react-helmet-async';
 import {
-  appDependenciesContext,
+  AppDependenciesContext,
   defaultAppDependenciesContext,
 } from 'appDependenciesContext';
 
@@ -25,13 +25,13 @@ const { store } = createConfiguredStore(history, __INITIAL_STATE__);
 const renderApp = (NewApp: typeof App = App) => {
   hydrate(
     <HelmetProvider>
-      <appDependenciesContext.Provider value={defaultAppDependenciesContext}>
+      <AppDependenciesContext.Provider value={defaultAppDependenciesContext}>
         <Provider store={store}>
           <Router history={history}>
             <NewApp />
           </Router>
         </Provider>
-      </appDependenciesContext.Provider>
+      </AppDependenciesContext.Provider>
     </HelmetProvider>,
     // tslint:disable-next-line:no-non-null-assertion
     document.getElementById('app')!,

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -31,7 +31,7 @@ import query from './NotablePersonQuery.graphql';
 import warningIcon from 'icons/warning.svg';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
-import { appDependenciesContext } from 'appDependenciesContext';
+import { AppDependenciesContext } from 'appDependenciesContext';
 
 const warningIconComponent = <SvgIcon {...warningIcon} size={100} />;
 
@@ -53,7 +53,7 @@ const Page = withRouter(
       const { slug } = this.props.match.params;
 
       return (
-        <appDependenciesContext.Consumer>
+        <AppDependenciesContext.Consumer>
           {dependencies => {
             return (
               <WithData
@@ -185,7 +185,7 @@ const Page = withRouter(
               </WithData>
             );
           }}
-        </appDependenciesContext.Consumer>
+        </AppDependenciesContext.Consumer>
       );
     }
   },

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -31,7 +31,7 @@ import query from './NotablePersonQuery.graphql';
 import warningIcon from 'icons/warning.svg';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
-import { AppDependenciesContext } from 'appDependenciesContext';
+import { AppDependenciesContext, AppDependencies } from 'appDependenciesContext';
 
 const warningIconComponent = <SvgIcon {...warningIcon} size={100} />;
 
@@ -41,7 +41,7 @@ const Page = withRouter(
   class extends React.Component<Props & RouteComponentProps<any>> {
     createLoad = ({
       apiClient,
-    }: Pick<AppDependenciesContext, 'apiClient'>) => async () => {
+    }: Pick<AppDependencies, 'apiClient'>) => async () => {
       const { slug } = this.props.match.params;
 
       return apiClient.request<NotablePersonQuery>(query, { slug });

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import cc from 'classcat';
 import Helmet from 'react-helmet-async';
-import { client } from 'api/client';
 
 import {
   isErrorResult,
@@ -32,6 +31,8 @@ import query from './NotablePersonQuery.graphql';
 import warningIcon from 'icons/warning.svg';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
+import { ApiContext } from 'client';
+import { GraphQLClient } from 'graphql-request';
 
 const warningIconComponent = <SvgIcon {...warningIcon} size={100} />;
 
@@ -39,10 +40,10 @@ export type Props = {};
 
 const Page = withRouter(
   class extends React.Component<Props & RouteComponentProps<any>> {
-    load = async () => {
+    createLoad = (apiClient: GraphQLClient) => async () => {
       const { slug } = this.props.match.params;
-
-      return client.request<NotablePersonQuery>(query, { slug });
+      
+      return apiClient.request<NotablePersonQuery>(query, { slug });
     };
 
     // tslint:disable:max-func-body-length
@@ -51,116 +52,122 @@ const Page = withRouter(
       const { slug } = this.props.match.params;
 
       return (
-        <WithData
-          requestId={slug}
-          dataKey="notablePersonQuery"
-          forPage={pageUrl}
-          load={this.load}
-        >
-          {({ result }: { result: AsyncResult<NotablePersonQuery | null> }) => {
-            if (result.value === null || isPendingResult(result)) {
-              return <NotablePersonSkeleton />;
-            }
-
-            if (isErrorResult(result)) {
-              const { location } = this.props;
-
-              return (
-                <MessageWithIcon
-                  title="Are you connected to the internet?"
-                  description="Please check your connection and try again"
-                  button={
-                    <LinkButton to={location} onClick={forceReload}>
-                      Reload
-                    </LinkButton>
-                  }
-                  icon={warningIconComponent}
-                >
-                  <Status code={500} />
-                </MessageWithIcon>
-              );
-            }
-
-            // tslint:disable-next-line:no-non-null-assertion
-            const { notablePerson } = result.value!;
-
-            if (!notablePerson) {
-              return (
-                <MessageWithIcon title="Not Found" icon={warningIconComponent}>
-                  <Status code={404} />
-                </MessageWithIcon>
-              );
-            }
-
-            const {
-              name,
-              mainPhoto,
-              summary,
-              commentsUrl,
-              editorialSummary,
-            } = notablePerson;
-
-            const isWhitelisted = isWhitelistedPage(`/${slug}`);
-
+        <ApiContext.Consumer>
+          {(apiClient) => {
             return (
-              <div className={classes.root}>
-                <Helmet>
-                  <link
-                    rel="canonical"
-                    href={
-                      isWhitelisted
-                        ? String(new URL(`${slug}`, 'https://hollowverse.com'))
-                        : commentsUrl
-                    }
-                  />
-                  <title>{`${name}'s Religion and Political Views`}</title>
-                </Helmet>
-                <Status code={200} />
-                <DispatchOnLifecycleEvent
-                  onWillUnmount={setAlternativeSearchBoxText(null)}
-                  onWillMount={setAlternativeSearchBoxText(notablePerson.name)}
-                />
-                <article className={classes.article}>
-                  <PersonDetails
-                    name={name}
-                    photo={mainPhoto}
-                    summary={summary}
-                  />
-                  {editorialSummary ? (
-                    <Card
-                      className={cc([classes.card, classes.editorialSummary])}
-                    >
-                      <EditorialSummary id={slug} {...editorialSummary} />
-                    </Card>
-                  ) : (
-                    <div className={classes.stub}>
-                      Share what you know about the religion and political views
-                      of {name} in the comments below
-                    </div>
-                  )}
-                </article>
-                {notablePerson.relatedPeople.length ? (
-                  <div className={classes.relatedPeople}>
-                    <h2>Other interesting profiles</h2>
-                    <RelatedPeople people={notablePerson.relatedPeople} />
-                  </div>
-                ) : null}
-                <OptionalIntersectionObserver
-                  rootMargin="0% 0% 25% 0%"
-                  triggerOnce
-                >
-                  {inView =>
-                    inView ? (
-                      <Card className={cc([classes.card, classes.comments])}>
-                        <FbComments url={commentsUrl} />
-                      </Card>
-                    ) : null
+              <WithData
+                requestId={slug}
+                dataKey="notablePersonQuery"
+                forPage={pageUrl}
+                load={this.createLoad(apiClient)}
+              >
+                {({ result }: { result: AsyncResult<NotablePersonQuery | null> }) => {
+                  if (result.value === null || isPendingResult(result)) {
+                    return <NotablePersonSkeleton />;
                   }
-                </OptionalIntersectionObserver>
-              </div>
+    
+                  if (isErrorResult(result)) {
+                    const { location } = this.props;
+    
+                    return (
+                      <MessageWithIcon
+                        title="Are you connected to the internet?"
+                        description="Please check your connection and try again"
+                        button={
+                          <LinkButton to={location} onClick={forceReload}>
+                            Reload
+                          </LinkButton>
+                        }
+                        icon={warningIconComponent}
+                      >
+                        <Status code={500} />
+                      </MessageWithIcon>
+                    );
+                  }
+    
+                  // tslint:disable-next-line:no-non-null-assertion
+                  const { notablePerson } = result.value!;
+    
+                  if (!notablePerson) {
+                    return (
+                      <MessageWithIcon title="Not Found" icon={warningIconComponent}>
+                        <Status code={404} />
+                      </MessageWithIcon>
+                    );
+                  }
+    
+                  const {
+                    name,
+                    mainPhoto,
+                    summary,
+                    commentsUrl,
+                    editorialSummary,
+                  } = notablePerson;
+    
+                  const isWhitelisted = isWhitelistedPage(`/${slug}`);
+    
+                  return (
+                    <div className={classes.root}>
+                      <Helmet>
+                        <link
+                          rel="canonical"
+                          href={
+                            isWhitelisted
+                              ? String(new URL(`${slug}`, 'https://hollowverse.com'))
+                              : commentsUrl
+                          }
+                        />
+                        <title>{`${name}'s Religion and Political Views`}</title>
+                      </Helmet>
+                      <Status code={200} />
+                      <DispatchOnLifecycleEvent
+                        onWillUnmount={setAlternativeSearchBoxText(null)}
+                        onWillMount={setAlternativeSearchBoxText(notablePerson.name)}
+                      />
+                      <article className={classes.article}>
+                        <PersonDetails
+                          name={name}
+                          photo={mainPhoto}
+                          summary={summary}
+                        />
+                        {editorialSummary ? (
+                          <Card
+                            className={cc([classes.card, classes.editorialSummary])}
+                          >
+                            <EditorialSummary id={slug} {...editorialSummary} />
+                          </Card>
+                        ) : (
+                          <div className={classes.stub}>
+                            Share what you know about the religion and political views
+                            of {name} in the comments below
+                          </div>
+                        )}
+                      </article>
+                      {notablePerson.relatedPeople.length ? (
+                        <div className={classes.relatedPeople}>
+                          <h2>Other interesting profiles</h2>
+                          <RelatedPeople people={notablePerson.relatedPeople} />
+                        </div>
+                      ) : null}
+                      <OptionalIntersectionObserver
+                        rootMargin="0% 0% 25% 0%"
+                        triggerOnce
+                      >
+                        {inView =>
+                          inView ? (
+                            <Card className={cc([classes.card, classes.comments])}>
+                              <FbComments url={commentsUrl} />
+                            </Card>
+                          ) : null
+                        }
+                      </OptionalIntersectionObserver>
+                    </div>
+                  );
+                }}
+              </WithData>
             );
           }}
-        </WithData>
+        </ApiContext.Consumer>
       );
     }
   },

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -31,7 +31,7 @@ import query from './NotablePersonQuery.graphql';
 import warningIcon from 'icons/warning.svg';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
-import { AppDependenciesContext } from 'client';
+import { AppDependenciesContext } from 'appDependenciesContext';
 
 const warningIconComponent = <SvgIcon {...warningIcon} size={100} />;
 

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -31,7 +31,7 @@ import query from './NotablePersonQuery.graphql';
 import warningIcon from 'icons/warning.svg';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
-import { AppDependenciesContext } from 'appDependenciesContext';
+import { appDependenciesContext } from 'appDependenciesContext';
 
 const warningIconComponent = <SvgIcon {...warningIcon} size={100} />;
 
@@ -53,7 +53,7 @@ const Page = withRouter(
       const { slug } = this.props.match.params;
 
       return (
-        <AppDependenciesContext.Consumer>
+        <appDependenciesContext.Consumer>
           {dependencies => {
             return (
               <WithData
@@ -185,7 +185,7 @@ const Page = withRouter(
               </WithData>
             );
           }}
-        </AppDependenciesContext.Consumer>
+        </appDependenciesContext.Consumer>
       );
     }
   },

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -31,8 +31,7 @@ import query from './NotablePersonQuery.graphql';
 import warningIcon from 'icons/warning.svg';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
-import { ApiContext } from 'client';
-import { GraphQLClient } from 'graphql-request';
+import { ApiContext, ApiClientContext } from 'client';
 
 const warningIconComponent = <SvgIcon {...warningIcon} size={100} />;
 
@@ -40,7 +39,7 @@ export type Props = {};
 
 const Page = withRouter(
   class extends React.Component<Props & RouteComponentProps<any>> {
-    createLoad = (apiClient: GraphQLClient) => async () => {
+    createLoad = (apiClient: ApiClientContext) => async () => {
       const { slug } = this.props.match.params;
       
       return apiClient.request<NotablePersonQuery>(query, { slug });

--- a/src/app/pages/SearchResults/SearchResults.tsx
+++ b/src/app/pages/SearchResults/SearchResults.tsx
@@ -29,7 +29,7 @@ import { searchResultSelected } from 'store/features/logging/actions';
 
 import { ResultsList } from './ResultsList';
 import { withRouter, RouteComponentProps } from 'react-router';
-import { appDependenciesContext } from 'appDependenciesContext';
+import { AppDependenciesContext } from 'appDependenciesContext';
 
 type Props = {
   searchQuery: string | null;
@@ -60,7 +60,7 @@ const Page = withRouter(
       const { searchQuery, location } = this.props;
 
       return (
-        <appDependenciesContext.Consumer>
+        <AppDependenciesContext.Consumer>
           {dependencies => {
             return (
               <div className={classes.root}>
@@ -147,7 +147,7 @@ const Page = withRouter(
               </div>
             );
           }}
-        </appDependenciesContext.Consumer>
+        </AppDependenciesContext.Consumer>
       );
     }
   },

--- a/src/app/pages/SearchResults/SearchResults.tsx
+++ b/src/app/pages/SearchResults/SearchResults.tsx
@@ -29,7 +29,7 @@ import { searchResultSelected } from 'store/features/logging/actions';
 
 import { ResultsList } from './ResultsList';
 import { withRouter, RouteComponentProps } from 'react-router';
-import { AppDependenciesContext } from 'appDependenciesContext';
+import { appDependenciesContext } from 'appDependenciesContext';
 
 type Props = {
   searchQuery: string | null;
@@ -60,7 +60,7 @@ const Page = withRouter(
       const { searchQuery, location } = this.props;
 
       return (
-        <AppDependenciesContext.Consumer>
+        <appDependenciesContext.Consumer>
           {dependencies => {
             return (
               <div className={classes.root}>
@@ -147,7 +147,7 @@ const Page = withRouter(
               </div>
             );
           }}
-        </AppDependenciesContext.Consumer>
+        </appDependenciesContext.Consumer>
       );
     }
   },

--- a/src/app/pages/SearchResults/SearchResults.tsx
+++ b/src/app/pages/SearchResults/SearchResults.tsx
@@ -29,7 +29,7 @@ import { searchResultSelected } from 'store/features/logging/actions';
 
 import { ResultsList } from './ResultsList';
 import { withRouter, RouteComponentProps } from 'react-router';
-import { AppDependenciesContext } from 'appDependenciesContext';
+import { AppDependenciesContext, AppDependencies } from 'appDependenciesContext';
 
 type Props = {
   searchQuery: string | null;
@@ -41,7 +41,7 @@ const Page = withRouter(
     createLoad = ({
       loadAlgoliaModule,
     }: Pick<
-      AppDependenciesContext,
+      AppDependencies,
       'loadAlgoliaModule'
     >) => async (): Promise<null | AlgoliaResponse> => {
       const { searchQuery } = this.props;

--- a/src/app/pages/SearchResults/SearchResults.tsx
+++ b/src/app/pages/SearchResults/SearchResults.tsx
@@ -29,7 +29,7 @@ import { searchResultSelected } from 'store/features/logging/actions';
 
 import { ResultsList } from './ResultsList';
 import { withRouter, RouteComponentProps } from 'react-router';
-import { AppDependenciesContext } from 'client';
+import { AppDependenciesContext } from 'appDependenciesContext';
 
 type Props = {
   searchQuery: string | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,6 +2671,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-context@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
+
 cross-fetch@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-0.0.8.tgz#01ed94dc407df2c00f1807fde700a7cfa48a205c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,10 +2238,6 @@ ci-env@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/ci-env/-/ci-env-1.5.2.tgz#6a1f025f32a3a14a8197359bf0cdb56699e4be2d"
 
-ci-info@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
-
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -2629,7 +2625,7 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-cosmiconfig@^3.0.0, cosmiconfig@^3.1.0:
+cosmiconfig@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
   dependencies:
@@ -4996,19 +4992,6 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-husky@^0.15.0-beta.16:
-  version "0.15.0-beta.16"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.15.0-beta.16.tgz#b9c2cfb2b42320e69dc92878f1511a82764cdf48"
-  dependencies:
-    cosmiconfig "^3.0.0"
-    execa "^0.8.0"
-    is-ci "^1.0.10"
-    pkg-dir "^2.0.0"
-    pupa "^1.0.0"
-    read-pkg "^3.0.0"
-    run-node "^0.1.1"
-    slash "^1.0.0"
-
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -5278,12 +5261,6 @@ is-builtin-module@^1.0.0:
 is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
-
-is-ci@^1.0.10:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
-  dependencies:
-    ci-info "^1.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -8066,10 +8043,6 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-pupa@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pupa/-/pupa-1.0.0.tgz#9a9568a5af7e657b8462a6e9d5328743560ceff6"
-
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -8937,10 +8910,6 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
-
-run-node@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-0.1.1.tgz#182ee9acd9a3b7ac5e6cf7679d5c33a1360c7b6f"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
The new context API moves context from an experimental feature of React to a first-class feature. I'm particularly interested in how the new API could improve our testing experience. Instead of having to tinker with Jest and Webpack and mock module files (which I really dislike), we could just swap the `value` prop of the `Provider` that wraps the `<App />` component with a mock implementation that we could create in the tests on the fly.

The new API works very well with static typing.

Note: this is using a polyfill for the new API, because the official API has been merged into React but not released yet.