### PR TITLE
Remove Set-Cookie header for static assets

### DIFF
--- a/src/appServer.ts
+++ b/src/appServer.ts
@@ -20,6 +20,11 @@ export const appServer = express();
 
 appServer.use(...securityMiddleware);
 
+const removeSetCookieHeader: express.RequestHandler = (_, res, next) => {
+  res.removeHeader('Set-Cookie');
+  next();
+};
+
 // Serve client build like usual
 // This must be defined before the SSR middleware so that
 // requests to static files, e.g. /static/app.js, are not
@@ -39,6 +44,22 @@ appServer.use(publicPath, [
     // Do not send index.html when requesting /
     index: false,
   }),
+
+  // When a response is cached with `Cache-Control: immutable` (see above), 
+  // the browser will not even send a request to check if the resource 
+  // has been updated. So if for example the user was on the `new-app` branch
+  // and they are switched to `master`, and if both branches has shared assets, the 
+  // browser will re-use the assets previously cached for `new-app`.
+  //
+  // Since the responses for these assets had `Set-Cookie: branch=new-app`,
+  // the environment which was just routed to `master` will be set again to
+  // `branch=new-app` when the asset is read from disk. So immutable caching
+  // is causing the environment to be reset again to the branch that the user
+  // was on when he first requested that asset.
+  // We should _not_ set the `Set-Cookie` header on static assets.
+
+  // See https://github.com/hollowverse/hollowverse/issues/287
+  removeSetCookieHeader,
 ]);
 
 // tslint:disable no-require-imports no-var-requires non-literal-require


### PR DESCRIPTION
When a response is cached with `Cache-Control: immutable`, the browser will not even send a request to check if the resource has been updated. So if for example the user was on the `new-app` branch and they are switched to `master`, and if both branches has shared assets, the browser will re-use the assets previously cached for `new-app`.

Since the responses for these assets had `Set-Cookie: branch=new-app`, the environment which was just routed to `master` will be set again to `branch=new-app` when the asset is read from disk. So immutable caching is causing the environment to be reset again to the branch that the user
was on when he first requested that asset.

We should _not_ set the `Set-Cookie` header on static assets.

Should hopefully fix https://github.com/hollowverse/hollowverse/issues/287