### PR TITLE
Refactor tests, fix CSS Module class names configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "pretest": "npm-run-all -l --aggregate-output -s app/graphql/build -p validate-filenames lint",
     "test": "run-p -l --aggregate-output app/test",
-    "app/test/webpack/dev": "NODE_ENV=test NO_TYPE_CHECK=1 yarn webpack --config src/webpack/webpack.config.test.js --watch",
+    "app/test/webpack/dev": "NODE_ENV=test NO_TYPE_CHECK=1 webpack --config src/webpack/webpack.config.test.js --watch",
     "app/test/jest/dev": "jest --watchAll",
     "app/test/dev": "npm-run-all -s clean/test -p 'app/test/*/dev'",
-    "app/test/webpack": "NODE_ENV=test yarn webpack --config src/webpack/webpack.config.test.js",
+    "app/test/webpack": "NODE_ENV=test webpack --config src/webpack/webpack.config.test.js",
     "app/test/jest": "jest",
     "app/test": "npm-run-all -s clean/test app/test/webpack app/test/jest",
     "lint": "run-p -l --aggregate-output lint-css lint-js lint-graphql lint-ts",

--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -1,103 +1,68 @@
-import { EpicDependencies } from 'store/createConfiguredStore';
-import createMemoryHistory from 'history/createMemoryHistory';
 import { getStatusCode } from 'store/features/status/reducer';
 import {
-  createTestTree,
   createMockGetResponseForDataRequest,
-  createConfiguredStoreForTests,
+  TestContext,
+  createTestContext,
 } from 'helpers/testHelpers';
-import { Store } from 'redux';
-import { StoreState } from 'store/types';
-import { History } from 'history';
 import { pageLoadSucceeded } from 'store/features/logging/actions';
-import { ReactWrapper, mount } from 'enzyme';
-import { delay } from 'helpers/delay';
 
 describe('Notable Person page', () => {
-  let wrapper: ReactWrapper<any>;
-  let store: Store<StoreState>;
-  let history: History | undefined;
-  let sendLogs: EpicDependencies['sendLogs'] | undefined;
-  let getNotablePersonResponse: EpicDependencies['getResponseForDataRequest'];
-  let initializeStoreAndTree: () => Promise<void>;
+  let context: TestContext;
 
-  beforeAll(() => {
-    initializeStoreAndTree = async () => {
-      ({ store, history } = createConfiguredStoreForTests({
-        epicDependenciesOverrides: {
-          getResponseForDataRequest: getNotablePersonResponse,
-          sendLogs,
-        },
-        history,
-      }));
-
-      const tree = createTestTree({
-        history,
-        store,
-      });
-
-      wrapper = mount(tree);
-
-      // Force promises to settle by scheduling
-      // the following statements after `setTimeout`
-      await delay(0);
-      wrapper.update();
-    };
-  });
-
-  beforeEach(() => {
+  beforeEach(async () => {
     expect.hasAssertions();
-    history = createMemoryHistory({ initialEntries: ['/Tom_Hanks'] });
-  });
-
-  afterEach(() => {
-    sendLogs = undefined;
-    history = undefined;
   });
 
   describe('When notable person is found,', () => {
     beforeEach(async () => {
-      getNotablePersonResponse = createMockGetResponseForDataRequest(
-        'notablePersonQuery',
-        {
-          notablePerson: {
-            commentsUrl: '',
-            name: 'Tom Hanks',
-            editorialSummary: null,
-            mainPhoto: null,
-            relatedPeople: [
-              {
+      context = await createTestContext({
+        epicDependenciesOverrides: {
+          getResponseForDataRequest: createMockGetResponseForDataRequest(
+            'notablePersonQuery',
+            {
+              notablePerson: {
+                commentsUrl: '',
+                name: 'Tom Hanks',
+                editorialSummary: null,
                 mainPhoto: null,
-                name: 'Al Pacino',
-                slug: 'Al_Pacino',
+                relatedPeople: [
+                  {
+                    mainPhoto: null,
+                    name: 'Al Pacino',
+                    slug: 'Al_Pacino',
+                  },
+                ],
+                slug: 'Tom_Hanks',
+                summary: null,
               },
-            ],
-            slug: 'Tom_Hanks',
-            summary: null,
-          },
+            },
+          ),
         },
-      );
-
-      await initializeStoreAndTree();
+        createHistoryOptions: { initialEntries: ['/Tom_Hanks'] },
+      });
     });
 
     it('returns 200', () => {
-      expect(getStatusCode(store.getState())).toBe(200);
+      expect(getStatusCode(context.store.getState())).toBe(200);
     });
 
     it('has notable person name', () => {
-      expect(wrapper).toIncludeText('Tom Hanks');
+      expect(context.wrapper).toIncludeText('Tom Hanks');
     });
 
     it('shows related people', () => {
-      expect(wrapper).toIncludeText('Al Pacino');
+      expect(context.wrapper).toIncludeText('Al Pacino');
     });
 
     describe('logs page load event', () => {
       beforeEach(async () => {
-        sendLogs = jest.fn();
-
-        await initializeStoreAndTree();
+        context = await createTestContext({
+          createHistoryOptions: { initialEntries: ['/Tom_Hanks'] },
+          epicDependenciesOverrides: {
+            ...context.dependencies,
+            sendLogs: jest.fn(),
+          },
+        });
       });
 
       beforeEach(done => {
@@ -110,8 +75,10 @@ describe('Notable Person page', () => {
 
       it('sends logs on page unload', () => {
         expect.hasAssertions();
-        expect(sendLogs).toHaveBeenLastCalledWith([
-          pageLoadSucceeded(history!.createHref(history!.location)),
+        expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith([
+          pageLoadSucceeded(
+            context.history.createHref(context.history.location),
+          ),
         ]);
       });
     });
@@ -119,22 +86,25 @@ describe('Notable Person page', () => {
 
   describe('When notable person is not found,', () => {
     beforeEach(async () => {
-      getNotablePersonResponse = createMockGetResponseForDataRequest(
-        'notablePersonQuery',
-        {
-          notablePerson: null,
+      context = await createTestContext({
+        createHistoryOptions: { initialEntries: ['/Tom_Hanks'] },
+        epicDependenciesOverrides: {
+          getResponseForDataRequest: createMockGetResponseForDataRequest(
+            'notablePersonQuery',
+            {
+              notablePerson: null,
+            },
+          ),
         },
-      );
-
-      await initializeStoreAndTree();
+      });
     });
 
     it('returns 404', () => {
-      expect(getStatusCode(store.getState())).toBe(404);
+      expect(getStatusCode(context.store.getState())).toBe(404);
     });
 
     it('shows "Not Found"', () => {
-      expect(wrapper).toIncludeText('Not Found');
+      expect(context.wrapper).toIncludeText('Not Found');
     });
   });
 });

--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -65,11 +65,13 @@ describe('Notable Person page', () => {
 
       it('sends logs on page unload', () => {
         expect.hasAssertions();
-        expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith([
-          pageLoadSucceeded(
-            context.history.createHref(context.history.location),
-          ),
-        ]);
+        expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            pageLoadSucceeded(
+              context.history.createHref(context.history.location),
+            ),
+          ]),
+        );
       });
     });
   });

--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -55,16 +55,6 @@ describe('Notable Person page', () => {
     });
 
     describe('logs page load event', () => {
-      beforeEach(async () => {
-        context = await createTestContext({
-          createHistoryOptions: { initialEntries: ['/Tom_Hanks'] },
-          epicDependenciesOverrides: {
-            ...context.dependencies,
-            sendLogs: jest.fn(),
-          },
-        });
-      });
-
       beforeEach(done => {
         window.addEventListener('unload', () => {
           done();

--- a/src/app/__tests__/searchPage.ts
+++ b/src/app/__tests__/searchPage.ts
@@ -1,103 +1,70 @@
-import { EpicDependencies } from 'store/createConfiguredStore';
-import createMemoryHistory from 'history/createMemoryHistory';
 import { getStatusCode } from 'store/features/status/reducer';
-import { mount, ReactWrapper } from 'enzyme';
 import {
-  createTestTree,
   createMockGetResponseForDataRequest,
-  createConfiguredStoreForTests,
+  TestContext,
+  createTestContext,
 } from 'helpers/testHelpers';
-import { Store } from 'redux';
-import { StoreState } from 'store/types';
-import { History } from 'history';
 import { delay } from 'helpers/delay';
 import { LoadingSpinner } from 'components/LoadingSpinner/LoadingSpinner';
 import { isSearchInProgress } from 'store/features/search/selectors';
-import { AlgoliaResponse } from 'algoliasearch';
+
+const stubNonEmptySearchResults = {
+  hits: [
+    {
+      slug: 'Tom_Hanks',
+      name: 'Tom Hanks',
+      mainPhoto: null,
+      objectID: '123',
+    },
+    {
+      slug: 'Tom_Hardy',
+      name: 'Tom Hardy',
+      mainPhoto: null,
+      objectID: '456',
+    },
+  ],
+  hitsPerPage: 10,
+  nbHits: 2,
+  nbPages: 1,
+  page: 0,
+  params: '',
+  processingTimeMS: 1,
+  query: 'Tom',
+};
 
 describe('Search page', () => {
-  let wrapper: ReactWrapper<any>;
-  let store: Store<StoreState>;
-  let history: History | undefined;
-  let getSearchResultsResponse: EpicDependencies['getResponseForDataRequest'];
-  let searchResults: AlgoliaResponse;
-  let initializeStoreAndTree: () => Promise<void>;
+  let context: TestContext;
 
-  beforeAll(() => {
-    initializeStoreAndTree = async () => {
-      ({ store, history } = createConfiguredStoreForTests({
-        epicDependenciesOverrides: {
-          getResponseForDataRequest: getSearchResultsResponse,
-        },
-        history,
-      }));
-
-      const tree = createTestTree({
-        history,
-        store,
-      });
-
-      wrapper = mount(tree);
-
-      // Force promises to settle by scheduling
-      // the following statements after `setTimeout`
-      await delay(0);
-      wrapper.update();
-    };
-  });
-
-  beforeEach(() => {
+  beforeEach(async () => {
     expect.hasAssertions();
-    searchResults = {
-      hits: [
-        {
-          slug: 'Tom_Hanks',
-          name: 'Tom Hanks',
-          mainPhoto: null,
-          objectID: '123',
-        },
-        {
-          slug: 'Tom_Hardy',
-          name: 'Tom Hardy',
-          mainPhoto: null,
-          objectID: '456',
-        },
-      ],
-      hitsPerPage: 10,
-      nbHits: 2,
-      nbPages: 1,
-      page: 0,
-      params: '',
-      processingTimeMS: 1,
-      query: 'Tom',
-    };
-
-    getSearchResultsResponse = createMockGetResponseForDataRequest(
-      'searchResults',
-      searchResults,
-    );
   });
 
   describe('While typing,', () => {
     beforeEach(async () => {
-      history = createMemoryHistory({ initialEntries: ['/search'] });
-
-      await initializeStoreAndTree();
+      context = await createTestContext({
+        createHistoryOptions: { initialEntries: ['/search'] },
+        epicDependenciesOverrides: {
+          getResponseForDataRequest: createMockGetResponseForDataRequest(
+            'searchResults',
+            stubNonEmptySearchResults,
+          ),
+        },
+      });
     });
 
     it('updates the URL to match the search query', () => {
-      const searchBox = wrapper.find('input[type="search"]');
+      const searchBox = context.wrapper.find('input[type="search"]');
       let params: URLSearchParams;
 
       searchBox.simulate('change', { target: { value: 'T' } });
 
-      params = new URLSearchParams(history!.location.search);
+      params = new URLSearchParams(context.history.location.search);
 
       expect(params.get('query')).toBe('T');
 
       searchBox.simulate('change', { target: { value: 'To' } });
 
-      params = new URLSearchParams(history!.location.search);
+      params = new URLSearchParams(context.history.location.search);
 
       expect(params.get('query')).toBe('To');
     });
@@ -105,50 +72,57 @@ describe('Search page', () => {
 
   describe('While results are being loaded,', () => {
     beforeEach(async () => {
-      history = createMemoryHistory({ initialEntries: ['/search'] });
+      context = await createTestContext({
+        createHistoryOptions: { initialEntries: ['/search'] },
+        epicDependenciesOverrides: {
+          getResponseForDataRequest: async payload => {
+            if (payload.key === 'searchResults') {
+              await delay(5000);
 
-      getSearchResultsResponse = async payload => {
-        if (payload.key === 'searchResults') {
-          await delay(5000);
+              return stubNonEmptySearchResults;
+            }
 
-          return searchResults;
-        }
-
-        return payload.load();
-      };
-
-      await initializeStoreAndTree();
+            return payload.load();
+          },
+        },
+      });
     });
 
     it('indicates loading status', () => {
-      expect(isSearchInProgress(store.getState())).toBe(false);
-      const searchBox = wrapper.find('input[type="search"]');
+      expect(isSearchInProgress(context.store.getState())).toBe(false);
+      const searchBox = context.wrapper.find('input[type="search"]');
       searchBox.simulate('change', { target: { value: 'T' } });
-      expect(isSearchInProgress(store.getState())).toBe(true);
-      expect(wrapper.find(LoadingSpinner)).toBePresent();
+      expect(isSearchInProgress(context.store.getState())).toBe(true);
+      expect(context.wrapper.find(LoadingSpinner)).toBePresent();
     });
   });
 
   describe('When results have finished loading,', () => {
     beforeEach(async () => {
-      history = createMemoryHistory({ initialEntries: ['/search?query=Tom'] });
-
-      await initializeStoreAndTree();
+      context = await createTestContext({
+        createHistoryOptions: { initialEntries: ['/search?query=Tom'] },
+        epicDependenciesOverrides: {
+          getResponseForDataRequest: createMockGetResponseForDataRequest(
+            'searchResults',
+            stubNonEmptySearchResults,
+          ),
+        },
+      });
     });
 
     describe('When results are found,', () => {
       it('returns 200', () => {
-        expect(getStatusCode(store.getState())).toBe(200);
+        expect(getStatusCode(context.store.getState())).toBe(200);
       });
 
       it('shows a list of results', () => {
-        expect(wrapper).toIncludeText('Tom Hanks');
-        expect(wrapper).toIncludeText('Tom Hardy');
+        expect(context.wrapper).toIncludeText('Tom Hanks');
+        expect(context.wrapper).toIncludeText('Tom Hardy');
       });
 
       it('results link to the respective notable person page', () => {
-        wrapper.find('li').forEach(li => {
-          for (const result of searchResults.hits) {
+        context.wrapper.find('li').forEach(li => {
+          for (const result of stubNonEmptySearchResults.hits) {
             if (li.contains(result.name)) {
               const a = li.find('a');
               expect(a).toBePresent();
@@ -161,31 +135,32 @@ describe('Search page', () => {
 
     describe('When no results are found,', () => {
       beforeEach(async () => {
-        searchResults = {
-          hits: [],
-          hitsPerPage: 10,
-          nbHits: 0,
-          nbPages: 1,
-          page: 0,
-          params: '',
-          processingTimeMS: 1,
-          query: 'Tom',
-        };
-
-        getSearchResultsResponse = createMockGetResponseForDataRequest(
-          'searchResults',
-          searchResults,
-        );
-
-        await initializeStoreAndTree();
+        context = await createTestContext({
+          createHistoryOptions: { initialEntries: ['/search?query=Tom'] },
+          epicDependenciesOverrides: {
+            getResponseForDataRequest: createMockGetResponseForDataRequest(
+              'searchResults',
+              {
+                hits: [],
+                hitsPerPage: 10,
+                nbHits: 0,
+                nbPages: 1,
+                page: 0,
+                params: '',
+                processingTimeMS: 1,
+                query: 'Tom',
+              },
+            ),
+          },
+        });
       });
 
       it('returns 404', () => {
-        expect(getStatusCode(store.getState())).toBe(404);
+        expect(getStatusCode(context.store.getState())).toBe(404);
       });
 
       it('shows "No results found"', () => {
-        expect(wrapper).toIncludeText('No results found');
+        expect(context.wrapper).toIncludeText('No results found');
       });
     });
   });

--- a/src/app/helpers/testHelpers.tsx
+++ b/src/app/helpers/testHelpers.tsx
@@ -94,6 +94,16 @@ export type CreateTestContextOptions = Partial<{
   createHistoryOptions: MemoryHistoryBuildOptions;
 }>;
 
+/**
+ * Creates a new app tree with a new store instance for each test
+ * The epic dependencies are replaced with mock functions so that we
+ * avoid sending actual network requests.
+ *
+ * The mock functions are created with `jest.fn()`
+ * so they can be spied on.
+ *
+ * Almost all configuration options can be overridden for convenience.
+ */
 export const createTestContext = async ({
   epicDependenciesOverrides = {},
   createHistoryOptions = { initialEntries: ['/'] },
@@ -104,9 +114,7 @@ export const createTestContext = async ({
       ...defaultTestDependencyOverrides,
       ...epicDependenciesOverrides,
     },
-    history: createMemoryHistory({
-      ...createHistoryOptions,
-    }),
+    history: createMemoryHistory(createHistoryOptions),
     ...rest,
   });
 

--- a/src/app/helpers/testHelpers.tsx
+++ b/src/app/helpers/testHelpers.tsx
@@ -117,8 +117,8 @@ export const createTestContext = async ({
 
   const wrapper = mount(tree);
 
-  // Force promises to settle by scheduling
-  // the following statements after `setTimeout`
+  // Wait for immediately-resolved promises
+  // to settle before executing the following statements
   await delay(0);
   wrapper.update();
 

--- a/src/webpack/shared.js
+++ b/src/webpack/shared.js
@@ -100,7 +100,7 @@ exports.createCssModulesLoaders = (isNode = false) => [
         // Do not scope the class names in tests, otherwise
         // every change to CSS styles will require updating the
         // snapshots.
-        ifTest('[name]') ||
+        ifTest('[name]__[local]') ||
         // Shorten the class name in production bundles to save some bytes
         ifProd('[hash:base64:5]') ||
         '[name]__[local]--[hash:base64:5]',

--- a/src/webpack/webpack.config.common.js
+++ b/src/webpack/webpack.config.common.js
@@ -22,7 +22,6 @@ const {
   ifEsNext,
 } = require('./env');
 
-
 module.exports.createCommonConfig = () => ({
   devServer:
     ifDev({


### PR DESCRIPTION
Instead of having multiple variables in the outer scope of each test, this PR leaves only one variable, `context`, and adds a helper function, `createTestContext`, that simplifies setting up the test tree and store.