### PR TITLE
Configure Babel to retain line positions in compiled output

### DIFF
--- a/src/webpack/babel.js
+++ b/src/webpack/babel.js
@@ -71,4 +71,5 @@ module.exports.createBabelConfig = (isNode = false) => ({
     ]),
   ]),
   sourceMap: 'both',
+  retainLines: true,
 });


### PR DESCRIPTION
[The `retainLines` option](https://babeljs.io/docs/usage/api/) instructs Babel to maintain the source line position in the compiled output.

> Retain line numbers. This will lead to wacky code but is handy for scenarios where you can’t use source maps. (NOTE: This will not retain the columns)

This should help with #309, although ideally correctly configured source maps should not need this.