### PR TITLE
Remove code coverage badge for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Hollowverse
 
-[![Build Status](https://travis-ci.org/hollowverse/hollowverse.svg?branch=master)](https://travis-ci.org/hollowverse/hollowverse)
-[![Coverage Status](https://coveralls.io/repos/github/hollowverse/hollowverse/badge.svg)](https://coveralls.io/github/hollowverse/hollowverse) [![Discord Badge](https://img.shields.io/discord/308394001789353985.svg)](https://discordapp.com/invite/KmnPYnu)
+[![Build Status](https://travis-ci.org/hollowverse/hollowverse.svg?branch=master)](https://travis-ci.org/hollowverse/hollowverse) [![Discord Badge](https://img.shields.io/discord/308394001789353985.svg)](https://discordapp.com/invite/KmnPYnu)
 
 Hollowverse is a website that focuses on the profound ideas of influential individuals.
 


### PR DESCRIPTION
From Discord discussion:

> mk: the badge being red on the README is not good. We don't wanna be desensitized to red alerts and such...so I think if we can't make it green, we should remove it.