### PR TITLE
Add NO_PROXY runtime flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "server/build": "tsc --project ./src",
     "build": "npm-run-all --aggregate-output -s clean -p app/build server/build",
     "start": "NODE_ENV=production run-p server/main-server/start",
-    "dev": "NODE_ENV=development API_ENDPOINT=${API_ENDPOINT:-https://api.hollowverse.com/graphql} npm-run-all --aggregate-output -s clean -p app/graphql/dev server/app-server/dev remotedev",
+    "dev": "NO_PROXY=${NO_PROXY:-1} NODE_ENV=development API_ENDPOINT=${API_ENDPOINT:-https://api.hollowverse.com/graphql} npm-run-all --aggregate-output -s clean -p app/graphql/dev server/app-server/dev remotedev",
     "test/dev": "run-p --aggregate-output app/test/dev",
     "clean": "del-cli './src/app/**/*.module.scss.d.ts' './dist' && mkdir -p ./dist",
     "clean/test": "del-cli './coverage' './__tests__/bundle' './__tests__/tests/!(__snapshots__)'",

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -24,7 +24,8 @@ export type CreateServerMiddlewareOptions = {
   routesMap: AppRoutesMap;
 };
 
-const isSsrDisabled = process.env.NO_SSR;
+const isSsrDisabled = Boolean(Number(process.env.NO_SSR));
+const isProxyDisabled = Boolean(Number(process.env.NO_PROXY));
 
 export const createServerEntryMiddleware = (
   options: CreateServerMiddlewareOptions,
@@ -76,6 +77,7 @@ export const createServerEntryMiddleware = (
         // /tom-hanks => redirect to Tom_Hanks
         res.redirect(redirectionPath);
       } else if (
+        isProxyDisabled ||
         isWhitelistedPage(requestPath) ||
         (await isNewSlug(requestPath.replace('/', '')))
       ) {

--- a/src/webpack/babel.js
+++ b/src/webpack/babel.js
@@ -62,9 +62,10 @@ module.exports.createBabelConfig = (isNode = false) => ({
       [
         'transform-inline-environment-variables',
         {
-          // Do not inline `NO_SSR` so that we can toggle this variable
-          // at runtime without having to re-build
-          exclude: ['NO_SSR'],
+          // Do not inline the following environment variables
+          // so that we can toggle this variable at runtime without
+          // having to re-build
+          exclude: ['NO_SSR', 'NO_PROXY'],
         },
       ],
       'lodash',


### PR DESCRIPTION
This flag is enabled by default in development mode, and allows us to test the new app on all pages without having to worry about some paths being redirected to the old website or getting `Cannot GET /` errors.

Fixes #324.