### PR TITLE
Do not consider query string when checking if page is whitelisted for indexing

### DIFF
--- a/src/app/components/App/App.tsx
+++ b/src/app/components/App/App.tsx
@@ -65,7 +65,7 @@ export const App = class extends React.Component<AppProps, State> {
         </Helmet>
         <Route>
           {props => {
-            if (!isWhitelistedPage(props.history.createHref(props.location))) {
+            if (!isWhitelistedPage(props.location.pathname)) {
               return (
                 <Helmet>
                   <meta name="robots" content="noindex" />


### PR DESCRIPTION
[Today's perf report](https://github.com/hollowverse/perf-reports/pull/4/files?short_path=d2ca99f#diff-d2ca99f561850f7704b080faa2424800) shows that we regressed in SEO. Checking the Lighthouse results on WebPageTest, this seems to be the reason:

> Page is blocked from indexing
> The "Robots" directives tell crawlers how your content should be indexed.

It turns out that this was because I added `?branch=master` at the end of the tested URLs and `isWhitelistedPage` was taking the query string into account when checking if the page is allowed to be indexed.