### PR TITLE
Fix overflowing PersonDetails content

### DIFF
--- a/src/app/components/PersonDetails/PersonDetails.module.scss
+++ b/src/app/components/PersonDetails/PersonDetails.module.scss
@@ -83,6 +83,7 @@
       width: 100%;
       max-width: $page-max-width;
       align-self: center;
+      overflow: hidden;
     }
 
     .photo-link {
@@ -141,6 +142,8 @@
     }
 
     &.is-loading {
+      overflow-x: hidden;
+
       .photo {
         @include photo-border(transparent, transparent);
       }


### PR DESCRIPTION
Fixes this (when no summary text is available)

![screenshot from 2018-03-08 20-32-08](https://user-images.githubusercontent.com/1012761/37169724-5de1f28c-2311-11e8-8523-f622bb3055c2.png)

Also fixes horizontal overflow of the moving illumination while loading.