### PR TITLE
Disable logging and analytics in development by default

### DIFF
--- a/src/app/store/createConfiguredStore.ts
+++ b/src/app/store/createConfiguredStore.ts
@@ -134,12 +134,13 @@ export function createConfiguredStore({
     });
   }
 
-  const rootEpic = combineEpics(
-    analyticsEpic,
-    updateUrlEpic,
-    dataResolverEpic,
-    loggingEpic,
-  );
+  const epics = [updateUrlEpic, dataResolverEpic];
+
+  if (process.env.NODE_ENV === 'production' || __FORCE_ENABLE_LOGGING__) {
+    epics.push(analyticsEpic, loggingEpic);
+  }
+
+  const rootEpic = combineEpics(...epics);
 
   const dependencies = {
     ...defaultEpicDependencies,

--- a/src/app/typings/global.d.ts
+++ b/src/app/typings/global.d.ts
@@ -27,3 +27,9 @@ declare const __BASE__: string;
 
 /** @example https://api.hollowverse.com/graphql */
 declare const __API_ENDPOINT__: string;
+
+/**
+ * By default, logging and analytics are disabled in development.
+ * Run `FORCE_ENABLE_LOGGING=1 yarn dev` to set this to `true` and force enable logging.
+ */
+declare const __FORCE_ENABLE_LOGGING__: boolean;

--- a/src/webpack/webpack.config.client.js
+++ b/src/webpack/webpack.config.client.js
@@ -11,7 +11,7 @@ const PreloadWebpackPlugin = require('preload-webpack-plugin');
 const NameAllModulesPlugin = require('name-all-modules-plugin');
 
 const path = require('path');
-const compact = require('lodash/compact');
+const { compact, mapValues } = require('lodash');
 
 const {
   createGlobalCssLoaders,
@@ -172,9 +172,15 @@ const clientSpecificConfig = {
     ifHot(new webpack.HotModuleReplacementPlugin()),
 
     // Environment
-    new webpack.DefinePlugin({
-      __IS_SERVER__: false,
-    }),
+    new webpack.DefinePlugin(
+      mapValues(
+        {
+          __IS_SERVER__: false,
+          __FORCE_ENABLE_LOGGING__: Boolean(process.env.FORCE_ENABLE_LOGGING),
+        },
+        v => JSON.stringify(v),
+      ),
+    ),
   ]),
 };
 

--- a/src/webpack/webpack.config.common.js
+++ b/src/webpack/webpack.config.common.js
@@ -157,7 +157,6 @@ module.exports.createCommonConfig = () => ({
           // which proxies the requests to the actual defined endpoint
           // The proxy is defined in appServer.ts
           __API_ENDPOINT__: isProd ? process.env.API_ENDPOINT : '/__api',
-          __FORCE_ENABLE_LOGGING__: Boolean(process.env.FORCE_ENABLE_LOGGING),
           'process.env.NODE_ENV': process.env.NODE_ENV,
           isHot,
         },

--- a/src/webpack/webpack.config.common.js
+++ b/src/webpack/webpack.config.common.js
@@ -157,6 +157,7 @@ module.exports.createCommonConfig = () => ({
           // which proxies the requests to the actual defined endpoint
           // The proxy is defined in appServer.ts
           __API_ENDPOINT__: isProd ? process.env.API_ENDPOINT : '/__api',
+          __FORCE_ENABLE_LOGGING__: Boolean(process.env.FORCE_ENABLE_LOGGING),
           'process.env.NODE_ENV': process.env.NODE_ENV,
           isHot,
         },

--- a/src/webpack/webpack.config.server.js
+++ b/src/webpack/webpack.config.server.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const path = require('path');
 const webpackMerge = require('webpack-merge');
 const { createCommonConfig } = require('./webpack.config.common');
-const compact = require('lodash/compact');
+const { compact, mapValues } = require('lodash');
 
 const common = createCommonConfig();
 
@@ -75,9 +75,15 @@ const serverSpecificConfig = {
     }),
 
     // Environment
-    new webpack.DefinePlugin({
-      __IS_SERVER__: true,
-    }),
+    new webpack.DefinePlugin(
+      mapValues(
+        {
+          __IS_SERVER__: true,
+          __FORCE_ENABLE_LOGGING__: Boolean(process.env.FORCE_ENABLE_LOGGING),
+        },
+        v => JSON.stringify(v),
+      ),
+    ),
 
     new webpack.ProvidePlugin({
       URL: ['url', 'URL'],

--- a/src/webpack/webpack.config.test.js
+++ b/src/webpack/webpack.config.test.js
@@ -140,6 +140,9 @@ const testSpecificConfig = {
       mapValues(
         {
           __IS_SERVER__: false,
+
+          // This won't actually send any logs or analytics, it's enabled
+          // to test the mock implementations of the logging functions.
           __FORCE_ENABLE_LOGGING__: true,
         },
         v => JSON.stringify(v),

--- a/src/webpack/webpack.config.test.js
+++ b/src/webpack/webpack.config.test.js
@@ -6,7 +6,7 @@ const NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin');
 const webpackMerge = require('webpack-merge');
 const StatsPlugin = require('stats-webpack-plugin');
 
-const { compact } = require('lodash');
+const { compact, mapValues } = require('lodash');
 const path = require('path');
 const WildcardsEntryWebpackPlugin = require('wildcards-entry-webpack-plugin');
 
@@ -136,9 +136,15 @@ const testSpecificConfig = {
     }),
 
     // Environment
-    new webpack.DefinePlugin({
-      __IS_SERVER__: false,
-    }),
+    new webpack.DefinePlugin(
+      mapValues(
+        {
+          __IS_SERVER__: false,
+          __FORCE_ENABLE_LOGGING__: true,
+        },
+        v => JSON.stringify(v),
+      ),
+    ),
   ]),
 };
 


### PR DESCRIPTION
For testing this functionality during development, we can use `FORCE_ENABLE_LOGGING=1 yarn dev`.

Closes #354 