### PR TITLE
Pass all environment variables strating with ENC_PASS_ or TRAVIS_ to build container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,8 @@ script:
     -e IS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
     -e AWS_ACCESS_KEY_ID
     -e AWS_SECRET_ACCESS_KEY
-    -e ENC_PASS_SUMO
-    -e TRAVIS
-    -e TRAVIS_JOB_ID
-    -e TRAVIS_JOB_NUMBER
-    -e TRAVIS_PULL_REQUEST
-    -e TRAVIS_BRANCH
-    -e TRAVIS_COMMIT
-    -e TRAVIS_REPO_SLUG
+    --env-file <(env | grep ENC_PASS_)
+    --env-file <(env | grep TRAVIS_)
     -e TRAVIS_BUILD_DIR=/repo
     hollowverse/build-env
 


### PR DESCRIPTION
If we add more secrets in the future, we don't have to remember to add them to the `docker run` command.