### PR TITLE
Fix API client not sending requests as GET

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "empty-module": "^0.0.2",
     "express": "^4.15.2",
     "graphql": "^0.11.0",
-    "graphql-request": "npm:@forabi/graphql-request@1.6.3",
+    "graphql-request": "npm:@forabi/graphql-request@1.6.4",
     "helmet": "^3.9.0",
     "history": "^4.6.3",
     "http-proxy": "^1.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,9 +5209,9 @@ graphql-request@^1.2.0, graphql-request@^1.4.0:
   dependencies:
     cross-fetch "0.0.8"
 
-"graphql-request@npm:@forabi/graphql-request@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@forabi/graphql-request/-/graphql-request-1.6.3.tgz#eaaf0d4487f4dcc47575baf69aa76208d3fb42ae"
+"graphql-request@npm:@forabi/graphql-request@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@forabi/graphql-request/-/graphql-request-1.6.4.tgz#889c641838b544aba6c7157e4853de6260f3b983"
   dependencies:
     cross-fetch "2.0.0"
 


### PR DESCRIPTION
Due to a [silly mistake](https://github.com/graphcool/graphql-request/pull/69/commits/b2a34dddd934039298ee66e98bca3a7688862dc7) in my patched `graphql-request`, specifying `GET` as the `method` did not take effect.