### PR TITLE
Attempt to fix different date strings by timezone in snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "app/test/jest/dev": "jest --color --watchAll",
     "app/test/dev": "npm-run-all --aggregate-output -s clean/test -p 'app/test/*/dev'",
     "app/test/webpack": "NODE_ENV=test webpack --config src/webpack/webpack.config.test.js",
-    "app/test/jest": "jest --coverage --verbose --color",
+    "app/test/jest": "TZ=UTC jest --coverage --verbose --color",
     "app/test": "run-s clean/test app/test/webpack app/test/jest coverage/remap",
     "lint": "run-p -c --aggregate-output lint-css lint-js lint-graphql lint-ts check-ts",
     "lint-css": "stylelint --syntax scss 'src/app/**/*.scss'",


### PR DESCRIPTION
The date string returned from the API does not have any timezone info (because the original data didn't). We have to assume a specific timezone to get constant date strings across different timezones.

Closes #393 