### PR TITLE
Improve build error output

### DIFF
--- a/build.js
+++ b/build.js
@@ -22,7 +22,14 @@ if (isProd) {
       );
     })
     .catch(err => {
-      console.error('Failed to build', err);
+      console.error('Failed to build');
+      if (Array.isArray(err) && typeof err[0].errors) {
+        err.forEach(webpackCompilerStats => {
+          console.error(webpackCompilerStats.toString('errors-only'));
+        });
+      } else {
+        console.error(err);
+      }
       process.exit(1);
     });
 } else {


### PR DESCRIPTION
Turn this unreadable mess:

![screenshot from 2018-04-10 22-56-13](https://user-images.githubusercontent.com/1012761/38580733-6c71a1fa-3d13-11e8-810c-1e55ebdd3d1d.png)

Into something useful:

![screenshot from 2018-04-10 22-56-30](https://user-images.githubusercontent.com/1012761/38580747-77155ef8-3d13-11e8-8078-69e7c064365f.png)

