### PR TITLE
Add promiseToCancelable helper, use it for AsyncComponent

### DIFF
--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -9,6 +9,9 @@ import {
 } from 'fixtures/notablePersonQuery';
 import { EditorialSummary } from 'components/EditorialSummary/EditorialSummary';
 
+const emptyBase64EncodedImage =
+  'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
 describe('Notable Person page', () => {
   let context: ClientSideTestContext;
 
@@ -120,8 +123,7 @@ describe('Notable Person page', () => {
               notablePerson: {
                 ...stubNotablePersonQueryResponse.notablePerson!,
                 mainPhoto: {
-                  url:
-                    'https://files.hollowverse.com/notable-people/Tom_Hanks.jpg',
+                  url: emptyBase64EncodedImage,
                   colorPalette: null,
                   sourceUrl:
                     'https://commons.wikimedia.org/wiki/File:Tom_Hanks_2014.jpg',
@@ -135,9 +137,7 @@ describe('Notable Person page', () => {
 
       it('shows notable person image', () => {
         expect(
-          context.wrapper.find(
-            `img[src="https://files.hollowverse.com/notable-people/Tom_Hanks.jpg"]`,
-          ),
+          context.wrapper.find(`img[src="${emptyBase64EncodedImage}"]`),
         ).toBePresent();
       });
 

--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -19,8 +19,6 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
     target.once('cancel', () => {
       wasCanceled = true;
       reject(cancelError);
-
-      return false;
     });
   });
 

--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'events';
+
+export type Cancelable<T> = Readonly<{
+  promise: Promise<T>;
+  wasCanceled: boolean;
+  cancel(): void;
+}>;
+
+type CancelRejection = Readonly<{ isCanceled: true }>;
+
+const cancelError: CancelRejection = { isCanceled: true };
+
+export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
+  let wasCanceled = false;
+
+  const target = new EventEmitter();
+  const cancelationPromise = new Promise<T>((_, reject) => {
+    target.on('cancel', () => {
+      wasCanceled = true;
+      reject(cancelError);
+
+      return false;
+    });
+  });
+
+  const wrappedPromise = Promise.race([cancelationPromise, promise]);
+
+  return {
+    promise: wrappedPromise,
+    get wasCanceled() {
+      return wasCanceled;
+    },
+    cancel() {
+      target.emit('cancel');
+    },
+  };
+}
+
+export function isCancelRejection(obj: any): obj is CancelRejection {
+  return 'isCanceled' in obj && obj.isCanceled === true;
+}

--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -9,7 +9,7 @@ export type Cancelable<T> = Readonly<{
 
 type CancelRejection = Readonly<{ isCanceled: true }>;
 
-const cancelRejection: CancelRejection = { isCanceled: true };
+const cancelRejection = Object.freeze<CancelRejection>({ isCanceled: true });
 
 export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
   let wasCanceled = false;

--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { once } from 'lodash';
 
 export type Cancelable<T> = Readonly<{
   promise: Promise<T>;
@@ -15,7 +16,7 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
 
   const target = new EventEmitter();
   const cancelationPromise = new Promise<T>((_, reject) => {
-    target.on('cancel', () => {
+    target.once('cancel', () => {
       wasCanceled = true;
       reject(cancelError);
 
@@ -30,9 +31,9 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
     get wasCanceled() {
       return wasCanceled;
     },
-    cancel() {
+    cancel: once(() => {
       target.emit('cancel');
-    },
+    }),
   };
 }
 

--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -9,7 +9,7 @@ export type Cancelable<T> = Readonly<{
 
 type CancelRejection = Readonly<{ isCanceled: true }>;
 
-const cancelError: CancelRejection = { isCanceled: true };
+const cancelRejection: CancelRejection = { isCanceled: true };
 
 export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
   let wasCanceled = false;
@@ -18,7 +18,7 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
   const cancelationPromise = new Promise<T>((_, reject) => {
     target.once('cancel', () => {
       wasCanceled = true;
-      reject(cancelError);
+      reject(cancelRejection);
     });
   });
 
@@ -36,5 +36,5 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
 }
 
 export function isCancelRejection(obj: any): obj is CancelRejection {
-  return 'isCanceled' in obj && obj.isCanceled === true;
+  return obj === cancelRejection;
 }


### PR DESCRIPTION
React throws an error when trying to `setState` on a component that has been unmounted. This is the case for `AsynComponent` when the `load` function completes after the async component has been removed from the tree. If the user navigates away from an `Image` that has started loading, the component will be unmounted by the time the load has finished.

Inspired by [this article](https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html) on the React blog, I've added a new `promiseToCancelable` function that gets rid of this error in `AsyncComponent`. It uses Node.js built-in `EventEmitter` (that also works in browser) to cancel the promise. Ideally we should use the browser's new standard [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) [but that just does not work in Jest](https://github.com/jsdom/jsdom/issues/2173#issuecomment-373509419).

Before:

![screenshot from 2018-04-13 21-14-18](https://user-images.githubusercontent.com/1012761/38751380-9b942ac6-3f60-11e8-97ed-39dcc0619659.png)

After:

![screenshot from 2018-04-13 21-22-11](https://user-images.githubusercontent.com/1012761/38751429-c5472cce-3f60-11e8-9b0f-b3ca4de6d024.png)
