### PR TITLE
Ensure cancel listener is removed on `Cancelable`

### DIFF
--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -15,14 +15,25 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
   let wasCanceled = false;
 
   const target = new EventEmitter();
+
   const cancelationPromise = new Promise<T>((_, reject) => {
-    target.once('cancel', () => {
+    target.addListener('cancel', () => {
       wasCanceled = true;
       reject(cancelRejection);
     });
   });
 
-  const wrappedPromise = Promise.race([cancelationPromise, promise]);
+  const wrappedPromise = Promise.race([cancelationPromise, promise])
+    .then(value => {
+      target.removeAllListeners();
+
+      return value;
+    })
+    .catch(error => {
+      target.removeAllListeners();
+
+      throw error;
+    });
 
   return {
     promise: wrappedPromise,


### PR DESCRIPTION
This avoids a possible memory leak where the listener does not get removed because the `cancel` event was never dispatched.