### PR TITLE
Refactor AsyncResult types and related components

### DIFF
--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -2,7 +2,10 @@ import {
   ClientSideTestContext,
   createClientSideTestContext,
 } from 'helpers/testHelpers';
-import { pageLoadSucceeded } from 'store/features/logging/actions';
+import {
+  pageLoadSucceeded,
+  pageLoadFailed,
+} from 'store/features/logging/actions';
 import {
   notablePersonWithEditorialSummaryQueryResponse,
   stubNotablePersonQueryResponse,
@@ -190,6 +193,26 @@ describe('Notable Person page', () => {
       );
       expect(linkButton).toBePresent();
       expect(linkButton.render().attr('href')).toMatch('/Tom_Hanks');
+    });
+
+    describe('logs page load failure event', () => {
+      beforeEach(done => {
+        window.addEventListener('unload', () => {
+          done();
+        });
+
+        window.dispatchEvent(new Event('unload'));
+      });
+
+      it('sends logs on page unload', () => {
+        expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            pageLoadFailed({
+              path: context.history.createHref(context.history.location),
+            }),
+          ]),
+        );
+      });
     });
   });
 

--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -178,7 +178,7 @@ describe('Notable Person page', () => {
         epicDependenciesOverrides: {
           getResponseForDataRequest: async payload => {
             if (payload.key === 'notablePersonQuery') {
-              throw new TypeError();
+              throw new TypeError('Network error');
             }
 
             return payload.load();
@@ -209,6 +209,7 @@ describe('Notable Person page', () => {
           expect.arrayContaining([
             pageLoadFailed({
               path: context.history.createHref(context.history.location),
+              error: 'Network error',
             }),
           ]),
         );

--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -45,9 +45,9 @@ describe('Notable Person page', () => {
       it('sends logs on page unload', () => {
         expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith(
           expect.arrayContaining([
-            pageLoadSucceeded(
-              context.history.createHref(context.history.location),
-            ),
+            pageLoadSucceeded({
+              path: context.history.createHref(context.history.location),
+            }),
           ]),
         );
       });

--- a/src/app/components/EditorialSummary/EditorialSummary.tsx
+++ b/src/app/components/EditorialSummary/EditorialSummary.tsx
@@ -6,6 +6,7 @@ import { prettifyUrl } from 'helpers/prettifyUrl';
 import { EditorialSummaryNodeType, NotablePersonQuery } from 'api/types';
 import { Quote } from 'components/Quote/Quote';
 import { Collapsable } from 'components/Collapsable/Collapsable';
+import { ArrayElement } from 'typings/typeHelpers';
 
 type NotablePerson = NonNullable<NotablePersonQuery['notablePerson']>;
 

--- a/src/app/components/FbComments/FbComments.tsx
+++ b/src/app/components/FbComments/FbComments.tsx
@@ -7,6 +7,7 @@ import { AsyncComponent } from 'hocs/AsyncComponent/AsyncComponent';
 
 import warningIcon from 'icons/warning.svg';
 import { Button } from 'components/Button/Button';
+import { isPendingResult, isErrorResult } from 'helpers/asyncResults';
 
 const warningIconComponent = <SvgIcon {...warningIcon} />;
 
@@ -105,12 +106,12 @@ export class FbComments extends React.PureComponent<Props> {
     return (
       <div {...rest}>
         <AsyncComponent load={this.load}>
-          {({ result: { hasError, isInProgress, hasTimedOut }, retry }) => {
-            if (hasError || hasTimedOut) {
+          {({ result, retry }) => {
+            if (isErrorResult(result) || result.hasTimedOut) {
               return (
                 <MessageWithIcon
                   title={
-                    hasTimedOut
+                    result.hasTimedOut
                       ? 'Comments are taking too long to load'
                       : 'Error loading comments'
                   }
@@ -119,6 +120,8 @@ export class FbComments extends React.PureComponent<Props> {
                 />
               );
             }
+
+            const isInProgress = isPendingResult(result);
 
             return (
               <div>

--- a/src/app/components/Image/Image.tsx
+++ b/src/app/components/Image/Image.tsx
@@ -8,6 +8,11 @@ export type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
 };
 
 import classes from './Image.module.scss';
+import {
+  isSuccessResult,
+  isErrorResult,
+  isPendingResult,
+} from 'helpers/asyncResults';
 
 /**
  * This component wraps a regular `<img>` tag and optionally shows
@@ -36,7 +41,7 @@ export class Image extends React.PureComponent<Props> {
   render() {
     return (
       <AsyncComponent delay={200} load={this.load}>
-        {({ result: { isInProgress, hasError } }) => {
+        {({ result }) => {
           const {
             className,
             loadingComponent,
@@ -44,11 +49,13 @@ export class Image extends React.PureComponent<Props> {
             ...rest
           } = this.props;
 
-          const hasLoaded = !isInProgress && !hasError;
+          const hasLoaded = isSuccessResult(result);
 
           if (hasLoaded) {
             return <img className={className} {...rest} />;
           }
+          const hasError = isErrorResult(result);
+          const isInProgress = isPendingResult(result);
 
           if (errorComponent !== undefined && hasError) {
             return errorComponent;

--- a/src/app/components/Image/Image.tsx
+++ b/src/app/components/Image/Image.tsx
@@ -49,11 +49,10 @@ export class Image extends React.PureComponent<Props> {
             ...rest
           } = this.props;
 
-          const hasLoaded = isSuccessResult(result);
-
-          if (hasLoaded) {
+          if (isSuccessResult(result)) {
             return <img className={className} {...rest} />;
           }
+
           const hasError = isErrorResult(result);
           const isInProgress = isPendingResult(result);
 

--- a/src/app/helpers/asyncResults.ts
+++ b/src/app/helpers/asyncResults.ts
@@ -3,6 +3,7 @@ import { DeepPartial } from 'typings/typeHelpers';
 export type ErrorResult = {
   state: 'error';
   value: undefined;
+  error?: Error;
 };
 
 type StaleResult<T> = {

--- a/src/app/helpers/asyncResults.ts
+++ b/src/app/helpers/asyncResults.ts
@@ -1,81 +1,80 @@
+import { DeepPartial } from 'typings/typeHelpers';
+
 export type ErrorResult = {
-  isInProgress: false;
-  hasError: true;
+  state: 'error';
   value: undefined;
 };
 
-type OptimisticResult<T> = {
-  isInProgress: true;
-  hasError: false;
+type StaleResult<T> = {
+  state: 'stale';
   value: T;
 };
 
+type OptimisticResult<T> = {
+  state: 'optimistic';
+  value: DeepPartial<T>;
+};
+
 export type PendingResult = {
-  isInProgress: true;
-  hasError: false;
+  state: 'pending';
   value: undefined;
 };
 
 export type SuccessResult<T> = {
-  isInProgress: false;
-  hasError: false;
+  state: 'success';
   value: T;
 };
 
 export type AsyncResult<T> =
   | ErrorResult
   | PendingResult
+  | StaleResult<T>
   | OptimisticResult<T>
   | SuccessResult<T>;
 
 export const pendingResult: PendingResult = {
-  isInProgress: true,
-  hasError: false,
+  state: 'pending',
   value: undefined,
 };
 
 export const errorResult: ErrorResult = {
-  isInProgress: false,
-  hasError: true,
+  state: 'error',
   value: undefined,
 };
 
 export const nullResult: SuccessResult<null> = {
-  isInProgress: false,
-  hasError: false,
+  state: 'success',
   value: null,
 };
 
 export function isErrorResult<T>(
   result: AsyncResult<T>,
 ): result is ErrorResult {
-  return result.hasError === true;
+  return result.state === 'error';
 }
 
 export function isPendingResult<T>(
   result: AsyncResult<T>,
 ): result is PendingResult {
-  return result.hasError === false && result.isInProgress === true;
+  return result.state === 'pending';
 }
 
 export function isOptimisticResult<T>(
   result: AsyncResult<T | null>,
 ): result is OptimisticResult<T> {
-  return (
-    result.value !== null &&
-    result.hasError === false &&
-    result.isInProgress === true
-  );
+  return result.state === 'optimistic';
+}
+
+export function isStaleResult<T>(
+  result: AsyncResult<T>,
+): result is StaleResult<T> {
+  return result.state === 'stale';
 }
 
 export function isSuccessResult<T>(
   result: AsyncResult<T>,
 ): result is SuccessResult<T> {
-  return (
-    result.hasError === false &&
-    result.isInProgress === false &&
-    result.value !== undefined
-  );
+  return result.state === 'success';
 }
 
 export async function promiseToAsyncResult<T>(
@@ -86,14 +85,12 @@ export async function promiseToAsyncResult<T>(
 
     return {
       value,
-      isInProgress: false,
-      hasError: false,
+      state: 'success',
     };
   } catch (e) {
     return {
       value: undefined,
-      isInProgress: false,
-      hasError: true,
+      state: 'error',
     };
   }
 }

--- a/src/app/helpers/asyncResults.ts
+++ b/src/app/helpers/asyncResults.ts
@@ -88,10 +88,11 @@ export async function promiseToAsyncResult<T>(
       value,
       state: 'success',
     };
-  } catch (e) {
+  } catch (error) {
     return {
       value: undefined,
       state: 'error',
+      error,
     };
   }
 }

--- a/src/app/helpers/testHelpers.tsx
+++ b/src/app/helpers/testHelpers.tsx
@@ -29,6 +29,7 @@ import { ContactUs } from 'pages/ContactUs/ContactUs';
 import { PrivacyPolicy } from 'pages/PrivacyPolicy/PrivacyPolicy';
 import { NotablePerson } from 'pages/NotablePerson/NotablePerson';
 import { Home } from 'pages/Home/Home';
+import { UnboxPromise } from 'typings/typeHelpers';
 
 const defaultRoutesMap: AppRoutesMap = {
   '/search': SearchResults,

--- a/src/app/hocs/AsyncComponent/AsyncComponent.tsx
+++ b/src/app/hocs/AsyncComponent/AsyncComponent.tsx
@@ -155,7 +155,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
               return;
             }
 
-            this.setState(errorResult);
+            this.setState(state => ({ ...state, ...errorResult, error }));
           });
       },
     );

--- a/src/app/hocs/AsyncComponent/AsyncComponent.tsx
+++ b/src/app/hocs/AsyncComponent/AsyncComponent.tsx
@@ -87,8 +87,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
   };
 
   state: State<T | null> = {
-    isInProgress: false,
-    hasError: false,
+    state: 'success',
     hasTimedOut: false,
     value: null,
     isPastDelay: false,
@@ -104,8 +103,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
     this.setState(
       {
         value: null,
-        isInProgress: !this.props.delay,
-        hasError: false,
+        state: this.props.delay ? 'success' : 'pending',
         hasTimedOut: false,
       },
       () => {
@@ -155,7 +153,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
 
             if (!patch.hasTimedOut) {
               const value = await loadPromise;
-              this.setState({ value, isInProgress: false });
+              this.setState({ value, state: 'success' });
             }
           })
           .catch(error => {
@@ -163,7 +161,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
               return;
             }
 
-            this.setState({ isInProgress: false, hasError: true });
+            this.setState({ state: 'error' });
           });
       },
     );

--- a/src/app/hocs/AsyncComponent/AsyncComponent.tsx
+++ b/src/app/hocs/AsyncComponent/AsyncComponent.tsx
@@ -5,6 +5,8 @@ import {
   PendingResult,
   SuccessResult,
   ErrorResult,
+  errorResult,
+  pendingResult,
 } from 'helpers/asyncResults';
 import {
   promiseToCancelable,
@@ -122,28 +124,20 @@ export class AsyncComponent<T = any> extends React.PureComponent<
 
         if (this.props.delay) {
           promises.push(
-            delay(this.props.delay).then(
-              () =>
-                ({
-                  // tslint:disable-next-line:no-object-literal-type-assertion
-                  isInProgress: true,
-                  isPastDelay: true,
-                } as Partial<PendingResult>),
-            ),
+            delay(this.props.delay).then(() => ({
+              ...pendingResult,
+              isPastDelay: true,
+            })),
           );
         }
 
         const { timeout } = this.props;
         if (timeout) {
           promises.push(
-            delay(timeout).then(
-              () =>
-                // tslint:disable-next-line:no-object-literal-type-assertion
-                ({
-                  hasError: true,
-                  hasTimedOut: true,
-                } as Partial<ErrorResult>),
-            ),
+            delay(timeout).then(() => ({
+              ...errorResult,
+              hasTimedOut: true,
+            })),
           );
         }
 
@@ -161,7 +155,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
               return;
             }
 
-            this.setState({ state: 'error' });
+            this.setState(errorResult);
           });
       },
     );

--- a/src/app/hocs/WithData/WithData.tsx
+++ b/src/app/hocs/WithData/WithData.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { AsyncResult, pendingResult } from 'helpers/asyncResults';
+import { AsyncResult } from 'helpers/asyncResults';
 import { ResolvedData, ResolvedDataKey, StoreState } from 'store/types';
 import { connect } from 'react-redux';
 import { getResolvedDataForKey } from 'store/features/asyncData/selectors';
@@ -29,6 +29,12 @@ type OwnProps<Key extends ResolvedDataKey = ResolvedDataKey> = {
    * the new results
    * @default `false`
    */
+  keepStaleData?: boolean;
+
+  /**
+   * An incomplete optimistic version of the data that is expected
+   * to be loaded.
+   */
   allowOptimisticUpdates?: boolean;
 
   /**
@@ -41,7 +47,7 @@ type OwnProps<Key extends ResolvedDataKey = ResolvedDataKey> = {
   /**
    * A function that receives the result of the `load` function when
    * it resolves. While resolving, children receive a pending result
-   * or an optimistic result depending on whether `allowOptimisitcUpdates`
+   * or an optimistic result depending on whether `allowOptimisticUpdates`
    * is enabled.
    */
   children({
@@ -67,19 +73,13 @@ type Props<K extends ResolvedDataKey = ResolvedDataKey> = OwnProps<K> &
 
 class Wrapper extends React.Component<Props> {
   resolve(props = this.props) {
-    const {
-      dataKey,
-      forPage,
-      load,
-      requestId,
-      allowOptimisticUpdates = false,
-    } = props;
+    const { dataKey, forPage, load, requestId, keepStaleData = false } = props;
     props.requestData({
       key: dataKey,
       requestId,
       forPage,
       load,
-      allowOptimisticUpdates,
+      keepStaleData,
     });
   }
 
@@ -96,17 +96,9 @@ class Wrapper extends React.Component<Props> {
   }
 
   render() {
-    const { result, requestId, allowOptimisticUpdates } = this.props;
-    let finalResult = result;
+    const { result } = this.props;
 
-    if (result.requestId !== requestId && !allowOptimisticUpdates) {
-      finalResult = {
-        ...pendingResult,
-        requestId,
-      };
-    }
-
-    return this.props.children({ result: finalResult });
+    return this.props.children({ result });
   }
 }
 

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -95,9 +95,9 @@ export const NotablePerson = withRouter(
       );
     };
 
-    renderErrorStatus = () => (
+    renderErrorStatus = (error?: Error) => (
       <>
-        <Status code={500} />
+        <Status code={500} error={error ? error.message : undefined} />
         <Helmet>
           <title>Error loading notable person page</title>
         </Helmet>
@@ -191,7 +191,7 @@ export const NotablePerson = withRouter(
               {({ result }: { result: Result }) => (
                 <div className={classes.root}>
                   {isErrorResult(result)
-                    ? this.renderErrorStatus()
+                    ? this.renderErrorStatus(result.error)
                     : this.renderNonErrorStatus(result)}
                 </div>
               )}

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -5,8 +5,9 @@ import { oneLine } from 'common-tags';
 
 import {
   isErrorResult,
-  isPendingResult,
   AsyncResult,
+  isSuccessResult,
+  ErrorResult,
 } from 'helpers/asyncResults';
 
 import { NotablePersonQuery } from 'api/types';
@@ -40,7 +41,7 @@ export type Props = {};
 type NotablePersonType = NotablePersonQuery['notablePerson'];
 type Result = AsyncResult<NotablePersonQuery | null>;
 
-const Page = withRouter(
+export const NotablePerson = withRouter(
   class extends React.Component<Props & RouteComponentProps<any>> {
     createLoad = ({
       apiClient,
@@ -162,17 +163,16 @@ const Page = withRouter(
       </>
     );
 
-    renderNonErrorStatus = (result: Result) => {
-      const notablePerson = result.value && result.value.notablePerson;
-      const isLoading = result.value === null || isPendingResult(result);
+    renderNonErrorStatus = (result: Exclude<Result, ErrorResult>) => {
+      if (isSuccessResult(result) && result.value !== null) {
+        if (result.value.notablePerson !== null) {
+          return this.render200Status(result.value.notablePerson);
+        }
 
-      if (isLoading) {
-        return <NotablePersonBody />;
-      } else if (notablePerson) {
-        return this.render200Status(notablePerson);
+        return this.render404Status();
       }
 
-      return this.render404Status();
+      return <NotablePersonBody />;
     };
 
     render() {
@@ -202,5 +202,3 @@ const Page = withRouter(
     }
   },
 );
-
-export const NotablePerson = Page;

--- a/src/app/pages/SearchResults/SearchResults.tsx
+++ b/src/app/pages/SearchResults/SearchResults.tsx
@@ -67,9 +67,9 @@ const Page = withRouter(
       </small>
     );
 
-    renderErrorStatus = () => (
+    renderErrorStatus = (error?: Error) => (
       <>
-        <Status code={500} />
+        <Status code={500} error={error ? error.message : undefined} />
         <Helmet>
           <title>Error loading search page</title>
         </Helmet>
@@ -145,7 +145,7 @@ const Page = withRouter(
 
     renderNonErrorStatus = (result: Exclude<Result, ErrorResult>) => {
       if (isSuccessResult(result) || isStaleResult(result)) {
-        const {value} = result;
+        const { value } = result;
 
         if (value && value.hits.length === 0) {
           return this.render404Status();
@@ -174,7 +174,7 @@ const Page = withRouter(
                   <div className={classes.resultsContainer}>
                     <Card className={classes.card}>
                       {isErrorResult(result)
-                        ? this.renderErrorStatus()
+                        ? this.renderErrorStatus(result.error)
                         : this.renderNonErrorStatus(result)}
                     </Card>
                   </div>

--- a/src/app/pages/SearchResults/SearchResults.tsx
+++ b/src/app/pages/SearchResults/SearchResults.tsx
@@ -9,8 +9,9 @@ import { Card } from 'components/Card/Card';
 import {
   AsyncResult,
   isSuccessResult,
-  isOptimisticResult,
   isErrorResult,
+  ErrorResult,
+  isStaleResult,
 } from 'helpers/asyncResults';
 import { AlgoliaResponse } from 'algoliasearch';
 import { connect } from 'react-redux';
@@ -47,7 +48,7 @@ const Page = withRouter(
     }: Pick<
       AppDependencies,
       'loadAlgoliaModule'
-    >) => async (): Promise<null | AlgoliaResponse> => {
+    >) => async (): Promise<AlgoliaResponse | null> => {
       const { searchQuery } = this.props;
 
       if (searchQuery) {
@@ -142,10 +143,10 @@ const Page = withRouter(
       );
     };
 
-    renderNonErrorStatus = (result: Result) => {
-      const { value } = result;
+    renderNonErrorStatus = (result: Exclude<Result, ErrorResult>) => {
+      if (isSuccessResult(result) || isStaleResult(result)) {
+        const {value} = result;
 
-      if (isSuccessResult(result) || isOptimisticResult(result)) {
         if (value && value.hits.length === 0) {
           return this.render404Status();
         }
@@ -166,7 +167,7 @@ const Page = withRouter(
               requestId={searchQuery}
               dataKey="searchResults"
               load={this.createLoad(dependencies)}
-              allowOptimisticUpdates
+              keepStaleData
             >
               {({ result }: { result: Result }) => (
                 <div className={classes.root}>

--- a/src/app/store/features/analytics/epic.ts
+++ b/src/app/store/features/analytics/epic.ts
@@ -37,7 +37,7 @@ export const analyticsEpic: Epic<Action, StoreState, EpicDependencies> = (
         tap(async action => {
           try {
             const ga = await initScript();
-            const path = action.payload;
+            const { path } = action.payload;
             ga('send', 'pageview', path);
           } catch (e) {
             // Do nothing

--- a/src/app/store/features/asyncData/epic.ts
+++ b/src/app/store/features/asyncData/epic.ts
@@ -7,11 +7,7 @@ import { Action, StoreState, SetResolvedDataPayload } from 'store/types';
 
 import { Epic } from 'redux-observable';
 
-import {
-  promiseToAsyncResult,
-  pendingResult,
-  isSuccessResult,
-} from 'helpers/asyncResults';
+import { promiseToAsyncResult, pendingResult } from 'helpers/asyncResults';
 import { isActionOfType } from 'store/helpers';
 import { getResolvedDataForKey } from 'store/features/asyncData/selectors';
 import { EpicDependencies } from 'store/createConfiguredStore';

--- a/src/app/store/features/logging/epic.ts
+++ b/src/app/store/features/logging/epic.ts
@@ -55,11 +55,11 @@ const mapPageLoadActions = ([setStatusCodeAction, locationChangeAction]: [
       to,
       statusCode: statusCodePayload.code,
     });
-  } else if (statusCodePayload.code !== 500) {
-    return pageLoadSucceeded({ path });
+  } else if (statusCodePayload.code === 500) {
+    return pageLoadFailed({ path, error: statusCodePayload.error });
   }
 
-  return pageLoadFailed({ path, error: statusCodePayload.error });
+  return pageLoadSucceeded({ path });
 };
 
 const comparePageLoadActions = (

--- a/src/app/store/features/logging/epic.ts
+++ b/src/app/store/features/logging/epic.ts
@@ -44,22 +44,22 @@ const mapPageLoadActions = ([setStatusCodeAction, locationChangeAction]: [
   Action<'SET_STATUS_CODE'>,
   Action<typeof LOCATION_CHANGE>
 ]) => {
-  const url = createPath(locationChangeAction.payload);
+  const path = createPath(locationChangeAction.payload);
   const statusCodePayload = setStatusCodeAction.payload;
 
   if (statusCodePayload.code === 301 || statusCodePayload.code === 302) {
     const to = statusCodePayload.redirectTo;
 
     return pageRedirected({
-      from: url,
+      from: path,
       to,
       statusCode: statusCodePayload.code,
     });
-  } else if (statusCodePayload.code < 500) {
-    return pageLoadSucceeded(url);
+  } else if (statusCodePayload.code !== 500) {
+    return pageLoadSucceeded({ path });
   }
 
-  return pageLoadFailed(url);
+  return pageLoadFailed({ path, error: statusCodePayload.error });
 };
 
 const comparePageLoadActions = (

--- a/src/app/store/features/search/selectors.ts
+++ b/src/app/store/features/search/selectors.ts
@@ -1,6 +1,10 @@
 import { StoreState } from 'store/types';
 import { createSelector } from 'reselect';
-import { isPendingResult, isStaleResult } from 'helpers/asyncResults';
+import {
+  isPendingResult,
+  isStaleResult,
+  isOptimisticResult,
+} from 'helpers/asyncResults';
 import { getRoutingState, isSearchPage } from 'store/features/url/selectors';
 
 const getSearchResults = (state: StoreState) =>
@@ -40,5 +44,8 @@ export const getSearchInputValue = createSelector(
 
 export const isSearchInProgress = createSelector(
   getSearchResults,
-  results => isPendingResult(results) || isStaleResult(results),
+  results =>
+    isPendingResult(results) ||
+    isStaleResult(results) ||
+    isOptimisticResult(results),
 );

--- a/src/app/store/features/search/selectors.ts
+++ b/src/app/store/features/search/selectors.ts
@@ -1,6 +1,6 @@
 import { StoreState } from 'store/types';
 import { createSelector } from 'reselect';
-import { isPendingResult, isOptimisticResult } from 'helpers/asyncResults';
+import { isPendingResult, isStaleResult } from 'helpers/asyncResults';
 import { getRoutingState, isSearchPage } from 'store/features/url/selectors';
 
 const getSearchResults = (state: StoreState) =>
@@ -40,5 +40,5 @@ export const getSearchInputValue = createSelector(
 
 export const isSearchInProgress = createSelector(
   getSearchResults,
-  results => isPendingResult(results) || isOptimisticResult(results),
+  results => isPendingResult(results) || isStaleResult(results),
 );

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -6,6 +6,7 @@ import {
 import { AsyncResult } from 'helpers/asyncResults';
 import { AlgoliaResponse } from 'algoliasearch';
 import { NotablePersonQuery } from 'api/types';
+import { DeepPartial } from 'typings/typeHelpers';
 
 export type ResolvedData = {
   notablePersonQuery: NotablePersonQuery | null;
@@ -21,7 +22,13 @@ export type RequestDataPayload<
    * Whether to keep the results of the previous request while loading
    * the new results
    */
-  allowOptimisticUpdates: boolean;
+  keepStaleData: boolean;
+
+  /**
+   * An incomplete optimistic version of the data that is expected
+   * to be loaded.
+   */
+  optimisticResponse?: DeepPartial<ResolvedData[Key]>;
 
   /**
    * The key used to store the results in Redux state
@@ -40,7 +47,7 @@ export type RequestDataPayload<
    */
   forPage?: string;
 
-  /** An asynchronous function that fetchs the data */
+  /** An asynchronous function that fetches the data */
   load(): Promise<ResolvedData[Key]>;
 };
 

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -79,7 +79,11 @@ export type ActionTypeToPayloadType = {
   SET_SHOULD_FOCUS_SEARCH: boolean;
   SET_STATUS_CODE:
     | {
-        code: 200 | 404 | 500;
+        code: 200 | 404;
+      }
+    | {
+        code: 500;
+        error?: string;
       }
     | {
         code: 301 | 302;
@@ -93,8 +97,8 @@ export type ActionTypeToPayloadType = {
     line?: number;
     column?: number;
   };
-  PAGE_LOAD_FAILED: string;
-  PAGE_LOAD_SUCCEEDED: string;
+  PAGE_LOAD_FAILED: { path: string; error?: string };
+  PAGE_LOAD_SUCCEEDED: { path: string };
   PAGE_REDIRECTED: {
     statusCode: 301 | 302;
     from: string;

--- a/src/app/typings/typeHelpers.d.ts
+++ b/src/app/typings/typeHelpers.d.ts
@@ -15,5 +15,5 @@ type NonPartialable =
   | any[];
 
 export type DeepPartial<T> = T extends NonPartialable
-  ? T
+  ? T // eslint-disable-next-line no-use-before-define
   : { [P in keyof T]?: T[P] extends NonPartialable ? T[P] : DeepPartial<T[P]> };

--- a/src/app/typings/typeHelpers.d.ts
+++ b/src/app/typings/typeHelpers.d.ts
@@ -1,3 +1,19 @@
-type UnboxPromise<T> = T extends Promise<infer R> ? R : T;
+export type UnboxPromise<T> = T extends Promise<infer R> ? R : T;
 
-type ArrayElement<T extends any[]> = T extends Array<infer R> ? R : never;
+export type ArrayElement<T extends any[]> = T extends Array<infer R>
+  ? R
+  : never;
+
+type NonPartialable =
+  | (() => any)
+  | undefined
+  | void
+  | never
+  | symbol
+  | string
+  | number
+  | any[];
+
+export type DeepPartial<T> = T extends NonPartialable
+  ? T
+  : { [P in keyof T]?: T[P] extends NonPartialable ? T[P] : DeepPartial<T[P]> };


### PR DESCRIPTION
Refactor `AsyncResult`, which is a ["discriminated union type"](http://www.typescriptlang.org/docs/handbook/advanced-types.html) to help the compiler infer types better.

Also introduce a new kind of `AsyncResult`: `StaleResult` which replaces what used to be `OptimisticResult`.

Re-use `OptimisticResult` to allow deep partial data respones.

Thanks to conditional types, we can now have a deep partial object that can be accessed safely.

This is useful for example for taking the notable person name and image from the search results and re-using them in `NotablePersonBody` while the full API query is being fetched.

Also be more strict with the parameter type of `renderNonErrorStatus`: it no longer silently accepts `ErrorResult` types.

Fixes #484 