### PR TITLE
Work around NavBar issue on Safari for iOS

### DIFF
--- a/src/app/components/App/App.module.scss
+++ b/src/app/components/App/App.module.scss
@@ -105,5 +105,10 @@
     > * {
       flex-grow: 1;
     }
+
+    /* #region Workaround for content jumping on navigation on Safari for iOS */
+    top: 48px;
+    position: absolute;
+    /* #endregion Workaround for content jumping on navigation on Safari for iOS */
   }
 }

--- a/src/app/components/LazyImage/LazyImage.tsx
+++ b/src/app/components/LazyImage/LazyImage.tsx
@@ -21,7 +21,7 @@ export class LazyImage extends React.PureComponent<Props> {
         triggerOnce
         className={outerClassName}
       >
-        {(inView: boolean) => {
+        {inView => {
           if (!inView) {
             return this.props.loadingComponent;
           }

--- a/src/app/components/ScrollTo/ScrollTo.tsx
+++ b/src/app/components/ScrollTo/ScrollTo.tsx
@@ -11,6 +11,12 @@ export class ScrollTo extends React.PureComponent<Props> {
     this.node = node;
   };
 
+  componentDidMount() {
+    if (this.node !== null) {
+      this.node.scrollIntoView(true);
+    }
+  }
+
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.updateKey !== nextProps.updateKey && this.node !== null) {
       this.node.scrollIntoView(true);

--- a/src/app/components/ScrollTo/ScrollTo.tsx
+++ b/src/app/components/ScrollTo/ScrollTo.tsx
@@ -11,15 +11,19 @@ export class ScrollTo extends React.PureComponent<Props> {
     this.node = node;
   };
 
-  componentDidMount() {
-    if (this.node !== null) {
+  scroll = () => {
+    if (this.node !== null && 'scrollIntoView' in this.node) {
       this.node.scrollIntoView(true);
     }
+  };
+
+  componentDidMount() {
+    this.scroll();
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    if (this.props.updateKey !== nextProps.updateKey && this.node !== null) {
-      this.node.scrollIntoView(true);
+    if (this.props.updateKey !== nextProps.updateKey) {
+      this.scroll();
     }
   }
 

--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -66,7 +66,7 @@ const Page = withRouter(
 
       return (
         <OptionalIntersectionObserver rootMargin="0% 0% 25% 0%" triggerOnce>
-          {(inView: boolean) =>
+          {inView =>
             inView ? (
               <Card className={cc([classes.card, classes.comments])}>
                 <FbComments url={commentsUrl} />


### PR DESCRIPTION
Force the content `position` to `absolute` and set the `top` to the height of the navigation bar. This is hacky and somewhat breaks the encapsulation of the `Sticky` component.

Fixes #428