### PR TITLE
Revert "Work around NavBar issue on Safari for iOS (#431)"

### DIFF
--- a/src/app/components/App/App.module.scss
+++ b/src/app/components/App/App.module.scss
@@ -105,10 +105,5 @@
     > * {
       flex-grow: 1;
     }
-
-    /* #region Workaround for content jumping on navigation on Safari for iOS */
-    top: 48px;
-    position: absolute;
-    /* #endregion Workaround for content jumping on navigation on Safari for iOS */
   }
 }


### PR DESCRIPTION
This reverts commit 11bec03006c0315ef9022da9f61d31c03c2017bc.

While this workaround did work, it prevented pages from having explitic heights so we could
no longer have the search results list take the whole height of the page even if empty.