### PR TITLE
Try to fix NotablePersonBody jumping while loading

### DIFF
--- a/src/app/pages/NotablePerson/LoadableNotablePerson.module.scss
+++ b/src/app/pages/NotablePerson/LoadableNotablePerson.module.scss
@@ -1,3 +1,13 @@
+@import 'variables.scss';
+
 .root {
-  composes: root from './NotablePerson.module.scss';
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: $spacing-20px;
+
+  > * {
+    width: 100%;
+    max-width: $page-max-width;
+  }
 }

--- a/src/app/pages/NotablePerson/LoadableNotablePerson.module.scss
+++ b/src/app/pages/NotablePerson/LoadableNotablePerson.module.scss
@@ -1,0 +1,3 @@
+.root {
+  composes: root from './NotablePerson.module.scss';
+}

--- a/src/app/pages/NotablePerson/LoadableNotablePerson.tsx
+++ b/src/app/pages/NotablePerson/LoadableNotablePerson.tsx
@@ -3,9 +3,15 @@ import loadable from 'react-loadable';
 import { NotablePersonBody } from './NotablePersonBody';
 import { loadableDefaultOptions } from 'helpers/loadableDefaultOptions';
 
+import classes from './LoadableNotablePerson.module.scss';
+
 export const LoadableNotablePerson = loadable({
   ...loadableDefaultOptions,
   loader: async () =>
     import('./NotablePerson').then(module => module.NotablePerson),
-  loading: () => <NotablePersonBody />,
+  loading: () => (
+    <div className={classes.root}>
+      <NotablePersonBody />
+    </div>
+  ),
 });

--- a/src/app/pages/NotablePerson/NotablePerson.module.scss
+++ b/src/app/pages/NotablePerson/NotablePerson.module.scss
@@ -2,15 +2,7 @@
 @import 'mixins.scss';
 
 .root {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-bottom: $spacing-20px;
-
-  > * {
-    width: 100%;
-    max-width: $page-max-width;
-  }
+  composes: root from './LoadableNotablePerson.module.scss';
 
   .card,
   .stub {

--- a/src/app/pages/NotablePerson/NotablePerson.module.scss
+++ b/src/app/pages/NotablePerson/NotablePerson.module.scss
@@ -7,6 +7,11 @@
   align-items: center;
   padding-bottom: $spacing-20px;
 
+  > * {
+    width: 100%;
+    max-width: $page-max-width;
+  }
+
   .card,
   .stub {
     padding: $spacing-20px;
@@ -15,11 +20,6 @@
   .comments {
     margin-top: $spacing-30px;
     padding: $spacing-10px;
-  }
-
-  > * {
-    width: 100%;
-    max-width: $page-max-width;
   }
 
   .editorial-summary {

--- a/src/webpack/createBaseConfig.js
+++ b/src/webpack/createBaseConfig.js
@@ -36,6 +36,7 @@ module.exports.createBaseConfig = () => ({
         },
       },
     },
+    host: '0.0.0.0',
     port: 8080,
     publicPath,
     hot: isHot,

--- a/src/webpack/helpers.js
+++ b/src/webpack/helpers.js
@@ -40,6 +40,7 @@ exports.createCssModulesLoaders = () => [
       sourceMap: true,
       modules: true,
       camelCase: 'only',
+      importLoaders: 2,
 
       localIdentName:
         // Shorten the class name in production bundles to save some bytes


### PR DESCRIPTION
Observations:

* It happens on all browsers, even on desktop, so it's not a Safari bug
* It happens only once when an NP page is loading for the first time. So it's most likely in `LodableNotablePerson`
* Looking at the structure of `loading` component in `LoadableNotablePerson` we see that it's not exactly the same as the fully loaded page:

```tsx
// loading
() => <NotablePersonBody />

// fully loaded
() => (
 <div classeName={classes.root}>
   <NotablePersonBody />
   {/* other components */}
 </div>
)
```

So I suspect it's being caused by some missing styles not being applied at the root of the loading component. We need to share some CSS rules between `LoadableNotablePerson` and `NotablePerson` and match the structure by adding a wrapper `<div />`.

It's very hard to test this in development because the styles are applied on the fly by `style-loader` and that causes a flash of unstyled text.