### PR TITLE
Change how Sticky works

### DIFF
--- a/src/app/components/Sticky/Sticky.module.scss
+++ b/src/app/components/Sticky/Sticky.module.scss
@@ -1,5 +1,16 @@
+@keyframes slide-down {
+  0% {
+    transform: translateY(-100px);
+  }
+
+  100% {
+    transform: translateY(0);
+  }
+}
+
 .container {
   position: relative;
+  width: 100%;
 
   .element,
   .placeholder {
@@ -9,11 +20,21 @@
   }
 
   .placeholder {
-    position: static;
-    visibility: hidden;
+    display: none;
   }
 
   .element {
-    position: fixed;
+    position: static;
+  }
+
+  &.is-sticking {
+    .placeholder {
+      display: block;
+    }
+
+    .element {
+      position: fixed;
+      animation: slide-down 0.2s ease-in-out;
+    }
   }
 }

--- a/src/app/components/Sticky/Sticky.tsx
+++ b/src/app/components/Sticky/Sticky.tsx
@@ -55,21 +55,29 @@ export class Sticky extends React.PureComponent<Props, State> {
     const { isSticking } = this.state;
 
     return (
-      <div className={cc([classes.container, className])}>
+      <div
+        className={cc([
+          classes.container,
+          className,
+          { [classes.isSticking]: isSticking },
+        ])}
+      >
         <OptionalIntersectionObserver
           threshold={1}
           rootMargin={rootMargin}
           onChange={this.handleChange}
         >
-          <div className={classes.placeholder} style={{ height }} />
+          <>
+            <div className={classes.placeholder} />
+            <div
+              className={cc([classes.element, innerClassName])}
+              {...rest}
+              style={{ height }}
+            >
+              {children(isSticking)}
+            </div>
+          </>
         </OptionalIntersectionObserver>
-        <div
-          className={cc([classes.element, innerClassName])}
-          {...rest}
-          style={{ height }}
-        >
-          {children(isSticking)}
-        </div>
       </div>
     );
   }


### PR DESCRIPTION
Following discussions in #428, this PR changes the behavior of the sticky navbar at the top to match what's described below:

> For example: we give the navbar position static (default positioning), and only when it has completely scrolled out of view, we change its positioning to fixed and animate it down.

I don't know if that fixes #428, I'm going to deploy this to `internal` branch and test the changes.