### PR TITLE
Wrap scroll call in requestAnimationFrame

### DIFF
--- a/src/app/components/ScrollTo/ScrollTo.tsx
+++ b/src/app/components/ScrollTo/ScrollTo.tsx
@@ -12,9 +12,11 @@ export class ScrollTo extends React.PureComponent<Props> {
   };
 
   scroll = () => {
-    if (this.node !== null && 'scrollIntoView' in this.node) {
-      this.node.scrollIntoView(true);
-    }
+    requestAnimationFrame(() => {
+      if (this.node !== null && 'scrollIntoView' in this.node) {
+        this.node.scrollIntoView(true);
+      }
+    });
   };
 
   componentDidMount() {


### PR DESCRIPTION
I suspect that Safari is throttling/skipping some calls to `scrollIntoView` which is leading to the issue described in #428.