### PR TITLE
Lint against unused and undefined CSS classes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "./node_modules/@hollowverse/config/eslint/base/.eslintrc.json",
-    "./node_modules/@hollowverse/config/eslint/graphql/.eslintrc.json"
+    "./node_modules/@hollowverse/config/eslint/graphql/.eslintrc.json",
+    "./node_modules/@hollowverse/config/eslint/cssModules/.eslintrc.json"
   ]
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@hollowverse/config/stylelint/.stylelintrc.json",
+  "extends": ["./node_modules/@hollowverse/config/stylelint/.stylelintrc.json"],
   "rules": {
     "plugin/no-unsupported-browser-features": [
       true,

--- a/clown.json
+++ b/clown.json
@@ -5,7 +5,7 @@
     "./node_modules/@hollowverse/config/clown/rxjs",
     "./node_modules/@hollowverse/config/clown/jest",
     "./node_modules/@hollowverse/config/clown/babel",
-    "./node_modules/@hollowverse/config/clown/stylelint",
+    "./node_modules/@hollowverse/config/clown/css",
     "./node_modules/@hollowverse/config/clown/lambda",
     "./clownOverrides"
   ]

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-compat": "^2.1.0",
+    "eslint-plugin-css-modules": "^2.7.5",
     "eslint-plugin-graphql": "^1.5.0",
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "@babel/preset-react": "^7.0.0-beta.46",
     "@babel/preset-stage-3": "^7.0.0-beta.46",
     "@hollowverse/clown": "^3.1.1",
-    "@hollowverse/config": "^33.0.0",
+    "@hollowverse/config": "^34.0.0",
     "@hollowverse/utils": "^6.0.1",
     "@hollowverse/validate-filenames": "^3.0.2",
     "@types/algoliasearch": "^3.24.5",

--- a/src/app/.eslintrc.json
+++ b/src/app/.eslintrc.json
@@ -1,15 +1,11 @@
 {
   "extends": [
     "../../node_modules/@hollowverse/config/eslint/browser/.eslintrc.json",
-    "../../node_modules/@hollowverse/config/eslint/react/typescript/.eslintrc.json",
-    "plugin:css-modules/recommended"
+    "../../node_modules/@hollowverse/config/eslint/react/typescript/.eslintrc.json"
   ],
-  "plugins": ["css-modules"],
   "rules": {
     "import/extensions": ["off"],
-    "import/no-webpack-loader-syntax": ["off"],
-    "css-modules/no-unused-class": ["error", { "camelCase": true }],
-    "css-modules/no-undef-class": ["error", { "camelCase": true }]
+    "import/no-webpack-loader-syntax": ["off"]
   },
   "env": {
     "browser": true,

--- a/src/app/.eslintrc.json
+++ b/src/app/.eslintrc.json
@@ -8,8 +8,8 @@
   "rules": {
     "import/extensions": ["off"],
     "import/no-webpack-loader-syntax": ["off"],
-    "css-modules/no-unused-class": [2, { "camelCase": true }],
-    "css-modules/no-undef-class": [2, { "camelCase": true }]
+    "css-modules/no-unused-class": ["error", { "camelCase": true }],
+    "css-modules/no-undef-class": ["error", { "camelCase": true }]
   },
   "env": {
     "browser": true,

--- a/src/app/.eslintrc.json
+++ b/src/app/.eslintrc.json
@@ -1,11 +1,15 @@
 {
   "extends": [
     "../../node_modules/@hollowverse/config/eslint/browser/.eslintrc.json",
-    "../../node_modules/@hollowverse/config/eslint/react/typescript/.eslintrc.json"
+    "../../node_modules/@hollowverse/config/eslint/react/typescript/.eslintrc.json",
+    "plugin:css-modules/recommended"
   ],
+  "plugins": ["css-modules"],
   "rules": {
     "import/extensions": ["off"],
-    "import/no-webpack-loader-syntax": ["off"]
+    "import/no-webpack-loader-syntax": ["off"],
+    "css-modules/no-unused-class": [2, { "camelCase": true }],
+    "css-modules/no-undef-class": [2, { "camelCase": true }]
   },
   "env": {
     "browser": true,

--- a/src/app/components/EditorialSummary/EditorialSummary.module.scss
+++ b/src/app/components/EditorialSummary/EditorialSummary.module.scss
@@ -12,10 +12,6 @@
     @include font-20px;
   }
 
-  .br {
-    display: block;
-  }
-
   > * + * {
     margin-top: $spacing-15px;
   }

--- a/src/app/components/NavBar/NavBar.module.scss
+++ b/src/app/components/NavBar/NavBar.module.scss
@@ -34,14 +34,6 @@
     }
   }
 
-  .sticky {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: stretch;
-  }
-
   .view-wrapper {
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.07);
     display: flex;

--- a/src/app/components/TextPage/TextPage.module.scss
+++ b/src/app/components/TextPage/TextPage.module.scss
@@ -99,13 +99,6 @@
       font-weight: normal;
     }
   }
-
-  .small {
-    @include font-13px;
-    line-height: 1.4;
-    margin-bottom: 10px;
-    color: $color-text-light;
-  }
 }
 
 @keyframes text-page {

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,9 +844,9 @@
     lodash "^4.17.4"
     sort-keys "^2.0.0"
 
-"@hollowverse/config@^33.0.0":
-  version "33.0.0"
-  resolved "https://registry.yarnpkg.com/@hollowverse/config/-/config-33.0.0.tgz#6ac5fcba05874af399dbd5d9a2654c9a4a2d6b3a"
+"@hollowverse/config@^34.0.0":
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/@hollowverse/config/-/config-34.0.0.tgz#a2ab48a9c49dcff8d2485a40f6af948a31d43d5d"
 
 "@hollowverse/utils@^6.0.1":
   version "6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,6 +5231,13 @@ eslint-plugin-compat@^2.1.0:
     mdn-browser-compat-data "^0.0.20"
     requireindex "^1.1.0"
 
+eslint-plugin-css-modules@^2.7.5:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.7.5.tgz#a4f49d3b585c721b37a8fee810af40373906bb1c"
+  dependencies:
+    gonzales-pe "^4.0.3"
+    lodash "^4.17.2"
+
 eslint-plugin-graphql@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-1.5.0.tgz#1f0861b6499906f7ce153f9e83633659e4374ef6"


### PR DESCRIPTION
I've been thinking about writing a TSLint plugin to do exactly this. Luckily I've found an ESLint plugin.

What this plugin does:

* Report any CSS Modules classes that are defined in CSS but not used in JSX/TSX files
* Report any CSS Modules classes that are used in JSX/TSX files but are not defined in CSS.

This combined with #452 should significantly improve the CSS development experience. It's like TypeScript for CSS :smile:

![screenshot from 2018-05-06 14-18-20](https://user-images.githubusercontent.com/1012761/39672719-74e110f8-5138-11e8-9df7-308be942df88.png)

![screenshot from 2018-05-06 14-11-43](https://user-images.githubusercontent.com/1012761/39672720-7716f4e6-5138-11e8-9c5a-98cb8c415c1f.png)
