### PR TITLE
Fix for index.html caching

### DIFF
--- a/src/entryMiddleware.ts
+++ b/src/entryMiddleware.ts
@@ -1,4 +1,4 @@
-import express, { RequestHandler } from 'express';
+import express, { RequestHandler, Response } from 'express';
 import path from 'path';
 import { isNewSlug } from 'isNewSlug';
 import { redirectionMap, isWhitelistedPage } from 'redirectionMap';
@@ -6,8 +6,16 @@ import { clientDistDirectory } from 'webpack/variables';
 
 const isProxyDisabled = Boolean(Number(process.env.NO_PROXY));
 
+const ONE_DAY_IN_SECONDS = 86400;
+
 const serveNewAppPage: RequestHandler = (_req, res) => {
   res.sendFile('index.html', {
+    setHeaders(staticResponse: Response) {
+      staticResponse.set(
+        'Cache-Control',
+        `public, max-age=${ONE_DAY_IN_SECONDS}, s-maxage=0`,
+      );
+    },
     root: path.resolve(clientDistDirectory),
 
     // MUST NOT set the `immutable` directive to `true` because `index.html` filename


### PR DESCRIPTION
By default, if no `max-age` or `s-maxage` is specified on objects in CloudFront, they will be cached for one day, so #447 didn't really fix the caching issue. Explicitly setting `s-maxage=0` on the `Cachce-Control` header forces CloudFront to not cache objects. We can still safely allow the browsers to cache the page for longer (`max-age`) because they should already have the scripts and stylesheets referenced by `index.html` cached immutably.

From the [CF docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesDefaultTTL)

> The value that you specify for *Default TTL* applies only when your origin does not add HTTP headers such as `Cache-Control max-age`, `Cache-Control s-maxage`, or `Expires` to objects.

> The default value for *Default TTL* is 86400 seconds (one day).

> If you want objects to stay in CloudFront edge caches for a different duration than they stay in browser caches, you can use the Cache-Control max-age and Cache-Control s-maxage directives together.