### PR TITLE
Update CloudFront invalidate plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "sass-loader": "^6.0.6",
     "serverless": "^1.26.1",
     "serverless-apigw-binary": "^0.4.4",
-    "serverless-cloudfront-invalidate": "^1.2.0",
+    "serverless-cloudfront-invalidate": "aghadiry/serverless-cloudfront-invalidate",
     "serverless-content-encoding": "^1.0.20",
     "serverless-plugin-typescript": "^1.1.5",
     "source-map-loader": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12701,9 +12701,9 @@ serverless-apigw-binary@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/serverless-apigw-binary/-/serverless-apigw-binary-0.4.4.tgz#f3cffd8365322a2a1d8bde5fd94b306b7a64d4fb"
 
-serverless-cloudfront-invalidate@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/serverless-cloudfront-invalidate/-/serverless-cloudfront-invalidate-1.2.0.tgz#44f4950a446cf83c7e1c3f99be93ff34b9d1138f"
+serverless-cloudfront-invalidate@aghadiry/serverless-cloudfront-invalidate:
+  version "1.1.0"
+  resolved "https://codeload.github.com/aghadiry/serverless-cloudfront-invalidate/tar.gz/632776b9d3d2b54edf4d3a45f0662adf51aee32f"
   dependencies:
     aws-sdk "^2.224.1"
     chalk "^2.3.1"


### PR DESCRIPTION
The latest version on npm has a bug which makes the plugin ineffective. We can use the GitHub repo in the meantime.