### PR TITLE
Fix related people images too big on desktop when less than 3 NPs are listed

### DIFF
--- a/src/app/pages/NotablePerson/RelatedPeople.module.scss
+++ b/src/app/pages/NotablePerson/RelatedPeople.module.scss
@@ -6,7 +6,7 @@
   list-style: none;
   max-width: $page-max-width;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: stretch;
   margin-top: $spacing-10px;
 
@@ -75,6 +75,7 @@
     $spacing: $spacing-2px;
     @include font-13px;
     flex: 1 0 calc(25% - #{$spacing});
+    max-width: calc(#{$page-max-width} / 4);
     display: flex;
     align-items: flex-start;
     padding: $spacing;


### PR DESCRIPTION
![screenshot from 2018-05-20 20-43-53](https://user-images.githubusercontent.com/1012761/40281859-fa9b4d44-5c6e-11e8-9487-0c7846a1e3a0.png)

Fixes #493 