### PR TITLE
Fix unhandled rejections

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "loggable",
     "loglevel",
     "middlewares",
+    "onunhandledrejection",
     "promisify",
     "unhandledrejection",
     "webpagetest"

--- a/src/app/helpers/promiseToCancelable.ts
+++ b/src/app/helpers/promiseToCancelable.ts
@@ -50,3 +50,9 @@ export function promiseToCancelable<T>(promise: Promise<T>): Cancelable<T> {
 export function isCancelRejection(obj: any): obj is CancelationError {
   return obj instanceof CancelationError;
 }
+
+export const ignoreCancelRejections = async (error: any) => {
+  if (!isCancelRejection(error)) {
+    throw error;
+  }
+};

--- a/src/app/hocs/AsyncComponent/AsyncComponent.tsx
+++ b/src/app/hocs/AsyncComponent/AsyncComponent.tsx
@@ -11,7 +11,7 @@ import {
 import {
   promiseToCancelable,
   Cancelable,
-  isCancelRejection,
+  ignoreCancelRejections,
 } from 'helpers/promiseToCancelable';
 
 type AsyncProps<T> = {
@@ -150,11 +150,8 @@ export class AsyncComponent<T = any> extends React.PureComponent<
               this.setState({ value, state: 'success' });
             }
           })
+          .catch(ignoreCancelRejections)
           .catch(error => {
-            if (isCancelRejection(error)) {
-              return;
-            }
-
             this.setState(state => ({ ...state, ...errorResult, error }));
           });
       },
@@ -167,6 +164,7 @@ export class AsyncComponent<T = any> extends React.PureComponent<
 
   componentWillUnmount() {
     if (this.cancelableLoad) {
+      this.cancelableLoad.promise.catch(ignoreCancelRejections);
       this.cancelableLoad.cancel('AsyncComponent unmounted');
     }
   }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -68,7 +68,7 @@ if (module.hot) {
 }
 
 Promise.all([loadIntersectionObserverPolyfill(), loadUrlPolyfill()])
-  .finally(renderOnDomReady)
+  .then(renderOnDomReady)
   .catch(renderOnDomReady);
 
 window.addEventListener(

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -88,17 +88,14 @@ window.addEventListener(
   },
 );
 
-window.addEventListener(
-  'unhandledrejection',
-  // @ts-ignore
-  ({ reason }: PromiseRejectionEvent) => {
-    store.dispatch(
-      unhandledErrorThrown({
-        location: pick(location, 'pathname', 'search', 'hash'),
-        name: 'Unhandled Rejection',
-        message: String(reason),
-        ...(isError(reason) ? reason : undefined),
-      }),
-    );
-  },
-);
+// @ts-ignore
+window.onunhandledrejection = ({ reason }: PromiseRejectionEvent) => {
+  store.dispatch(
+    unhandledErrorThrown({
+      location: pick(location, 'pathname', 'search', 'hash'),
+      name: 'Unhandled Rejection',
+      message: String(reason),
+      ...(isError(reason) ? reason : undefined),
+    }),
+  );
+};


### PR DESCRIPTION
This should bring the error rate down as most of the errors are likely CancelationErrors.

It looks like the Promise polyfill provided by core-js (which is added by @babel/preset-env) does not support this way of handling rejections:

```ts
window.addEventListener('unhandledrejection', /* ... */)
```

and only works with:

```ts
window.onunhandledrejection = /* ... */;
```

I can confirm this after looking [into the code](https://github.com/zloirock/core-js/blob/de5ed6f6d00f5bac314aa804262217da85a3e88d/modules/es6.promise.js#L100).
