### PR TITLE
Preload Search page on Notable Person page

### DIFF
--- a/src/app/pages/NotablePerson/NotablePerson.tsx
+++ b/src/app/pages/NotablePerson/NotablePerson.tsx
@@ -37,6 +37,8 @@ import classes from './NotablePerson.module.scss';
 import { setAlternativeSearchBoxText } from 'store/features/search/actions';
 import { isWhitelistedPage } from 'redirectionMap';
 
+import { LoadableSearchResults } from 'pages/SearchResults/LoadableSearchResults';
+
 export type Props = {};
 type NotablePersonType = NotablePersonQuery['notablePerson'];
 type Result = AsyncResult<NotablePersonQuery | null>;
@@ -48,7 +50,13 @@ export const NotablePerson = withRouter(
     }: Pick<AppDependencies, 'apiClient'>) => async () => {
       const { slug } = this.props.match.params;
 
-      return apiClient.request<NotablePersonQuery>(query, { slug });
+      const result = await apiClient.request<NotablePersonQuery>(query, {
+        slug,
+      });
+
+      LoadableSearchResults.preload();
+
+      return result;
     };
 
     renderRelatedPeople = (notablePerson: NonNullable<NotablePersonType>) => {


### PR DESCRIPTION
Looks like most users land on the website via NP pages and it's likely that the next page they visit is the search page. This change preloads the search page so it feels faster when users hit the search button.

* The search page load is delayed until the NP API query is finished to avoid slowing down the NP page load.
* Calling `LoadableSearchResults.preload()` multiple times is fine. It will only be fetched once.