### PR TITLE
Use visibilitychange event to send logs

### DIFF
--- a/src/app/__tests__/notablePersonPage.ts
+++ b/src/app/__tests__/notablePersonPage.ts
@@ -2,6 +2,7 @@ import {
   TestContext,
   createTestContext,
   assertPageHasReloadButton,
+  setUpLogListener,
 } from 'helpers/testHelpers';
 import {
   pageLoadSucceeded,
@@ -37,15 +38,9 @@ describe('notable person page', () => {
     });
 
     describe('logs page load event', () => {
-      beforeEach(done => {
-        window.addEventListener('unload', () => {
-          done();
-        });
+      beforeEach(setUpLogListener);
 
-        window.dispatchEvent(new Event('unload'));
-      });
-
-      it('sends logs on page unload', () => {
+      it('sends logs on page hide', () => {
         expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith(
           expect.objectContaining({
             actions: expect.arrayContaining([
@@ -200,15 +195,9 @@ describe('notable person page', () => {
     });
 
     describe('logs page load failure event', () => {
-      beforeEach(done => {
-        window.addEventListener('unload', () => {
-          done();
-        });
+      beforeEach(setUpLogListener);
 
-        window.dispatchEvent(new Event('unload'));
-      });
-
-      it('sends logs on page unload', () => {
+      it('sends logs on page hide', () => {
         expect(context.dependencies.sendLogs).toHaveBeenLastCalledWith(
           expect.objectContaining({
             actions: expect.arrayContaining([

--- a/src/app/helpers/testHelpers.tsx
+++ b/src/app/helpers/testHelpers.tsx
@@ -72,6 +72,14 @@ export const createMockGetResponseForDataRequest = (
   return payload.load();
 };
 
+export const setUpLogListener: jest.ProvidesCallback = done => {
+  window.addEventListener('pagehide', () => {
+    done();
+  });
+
+  window.dispatchEvent(new Event('pagehide'));
+};
+
 type CreateMockFbSdkOption = {
   onLoginRequested?(): FB.LoginStatusResponse;
   onLogoutRequested?(): FB.LoginStatusResponse;
@@ -275,6 +283,8 @@ export const createTestContext = async ({
   mockDataResponsesOverrides = {},
   ...rest
 }: Partial<CreateClientSideTestContextOptions> = {}) => {
+  jest.restoreAllMocks();
+
   const { store, dependencies, history } = createConfiguredStore({
     epicDependenciesOverrides: {
       ...defaultTestDependencyOverrides,

--- a/src/app/store/features/logging/epic.ts
+++ b/src/app/store/features/logging/epic.ts
@@ -120,7 +120,7 @@ export const loggingEpic: Epic<Action, StoreState, EpicDependencies> = (
       ),
     );
 
-    const flushOnUnload$ = merge(
+    const flushOnPageVisibilityChange$ = merge(
       // See https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/
       observableFromEvent(document, 'visibilitychange').pipe(
         filter(() => document.visibilityState === 'hidden'),
@@ -128,7 +128,9 @@ export const loggingEpic: Epic<Action, StoreState, EpicDependencies> = (
       observableFromEvent(window, 'pagehide'),
     );
 
-    const logOnUnload$ = loggableActions$.pipe(buffer(flushOnUnload$));
+    const logOnUnload$ = loggableActions$.pipe(
+      buffer(flushOnPageVisibilityChange$),
+    );
     const logOnIdle$ = loggableActions$.pipe(bufferCount(10));
 
     return merge(logOnIdle$, logOnUnload$).pipe(

--- a/src/app/store/features/logging/epic.ts
+++ b/src/app/store/features/logging/epic.ts
@@ -121,9 +121,11 @@ export const loggingEpic: Epic<Action, StoreState, EpicDependencies> = (
     );
 
     const flushOnUnload$ = merge(
-      // `pagehide` is for Safari
+      // See https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/
+      observableFromEvent(document, 'visibilitychange').pipe(
+        filter(() => document.visibilityState === 'hidden'),
+      ),
       observableFromEvent(window, 'pagehide'),
-      observableFromEvent(window, 'unload'),
     );
 
     const logOnUnload$ = loggableActions$.pipe(buffer(flushOnUnload$));


### PR DESCRIPTION
This works more reliably than the `unload` event across desktop and mobile browsers.

See https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/