### PR TITLE
Switch to uppercase enum values for API types

### DIFF
--- a/src/app/components/EditorialSummary/EditorialSummary.tsx
+++ b/src/app/components/EditorialSummary/EditorialSummary.tsx
@@ -1,5 +1,3 @@
-/* tslint:disable no-unnecessary-type-assertion */
-
 import React from 'react';
 import formatDate from 'date-fns/format';
 
@@ -59,7 +57,7 @@ const isBlockNode = (node: Node) =>
     EditorialSummaryNodeType.HEADING,
     EditorialSummaryNodeType.PARAGRAPH,
     EditorialSummaryNodeType.QUOTE,
-  ].includes(node.type.toUpperCase() as EditorialSummaryNodeType);
+  ].includes(node.type);
 
 const isRootBlock = (node: Node) => !node.parentId;
 
@@ -81,13 +79,7 @@ type BlockProps = {
 const Block = (props: BlockProps): JSX.Element => {
   const { node, nodes, referencesMap, onSourceClick } = props;
 
-  // eslint-disable-next-line no-param-reassign
-  node.type = node.type.toUpperCase() as EditorialSummaryNodeType;
-
   const children = findChildren(node, nodes).map(child => {
-    // eslint-disable-next-line no-param-reassign
-    child.type = child.type.toUpperCase() as EditorialSummaryNodeType;
-
     if (isBlockNode(child)) {
       return <Block key={child.id} {...props} node={child} />;
     } else if (child.type === 'LINK' && child.sourceUrl) {
@@ -149,7 +141,7 @@ const Block = (props: BlockProps): JSX.Element => {
  */
 const findRefs = (nodes: Node[], map: Map<Node, Source>) => (node: Node) => {
   const { sourceUrl, sourceTitle, type } = node;
-  if (sourceUrl && type.toUpperCase() !== 'LINK') {
+  if (sourceUrl && type !== 'LINK') {
     const number = map.size + 1;
     map.set(node, {
       number,

--- a/src/app/fixtures/notablePersonQuery.ts
+++ b/src/app/fixtures/notablePersonQuery.ts
@@ -30,7 +30,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
       nodes: [
         {
           id: '020e9702-42ae-40c4-957d-19da0367d161',
-          type: 'text',
+          type: 'TEXT',
           text:
             "Politically, Hanks falls squarely in the Democrat/liberal camp, like the vast majority of his Hollywood counterparts. He's stuck up for quite a few liberal causes like gay marriage and the environment, and has a large collection of electric and hybrid cars.",
           sourceUrl: null,
@@ -39,7 +39,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '0929c823-1f60-466d-a69f-332508ea6796',
-          type: 'text',
+          type: 'TEXT',
           text:
             'He even slandered his old church–The Church of Jesus Christ of Latter Day Saints (Mormons) when they donated money to advance proposition 8 in California, effectively banning gay marriage.',
           sourceUrl:
@@ -49,7 +49,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '25b14ef1-9b83-4442-b463-66c05b7961e3',
-          type: 'text',
+          type: 'TEXT',
           text:
             "His religious beliefs are about as diverse as the characters he has played. Hanks' childhood was a hodgepodge of divorce and step-parents, each with their own views. Hanks has identified with everything from Mormonism to his most recent and enduring faith–Greek Orthodox. In his own words:",
           sourceUrl: null,
@@ -58,7 +58,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '4f2b79e7-fd89-47af-ba59-7e5e5113d21f',
-          type: 'text',
+          type: 'TEXT',
           text:
             'The major religion I was exposed to in the first 10 years of my life was Catholicism. My stepmother became a Mormon. My aunt, whom I lived with for a long time, was a Nazarene, which is kind of ultra-super Methodist, and in high school, all my friends were Jews. For years I went to Wednesday-night Bible studies with my church group. So I had this peripatetic overview of various faiths, and the one thing I got from that was the intellectual pursuit involved. There was a lot of great stuff to think about.',
           sourceUrl:
@@ -68,7 +68,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '767ce7a4-db21-47e1-bb25-e98e011e0ce5',
-          type: 'text',
+          type: 'TEXT',
           text:
             'Hanks backed Obama in 2008, posting a video on his Myspace page, explaining his position.',
           sourceUrl: 'http://www.myspace.com/video/vid/33546997',
@@ -77,7 +77,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '882b92ff-cc0d-451d-96cd-7d7bc9b1da64',
-          type: 'text',
+          type: 'TEXT',
           text:
             'In 2012, Hanks forcefully said he would back Obama once again and, despite widespread opinion to the opposite effect, said Obama had exceeded his expectations, saying:',
           sourceUrl: null,
@@ -86,7 +86,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '89740c08-4795-48d9-afb0-eb6722b8003f',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -94,7 +94,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '94e61f0d-e0e8-443e-871e-15337ff79c81',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -102,7 +102,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '95d14bf8-024b-4836-8162-f7bae0cda9d9',
-          type: 'text',
+          type: 'TEXT',
           text: 'Tom Hanks was born in Concord, California.',
           sourceUrl: null,
           sourceTitle: null,
@@ -110,7 +110,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'cd31fcb5-49a1-4c7e-8eea-1e4c437b71f5',
-          type: 'text',
+          type: 'TEXT',
           text:
             'Hanks is said to be a deeply religious man and goes to church regularly.',
           sourceUrl:
@@ -120,7 +120,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'db8110f0-5b1e-4895-a6c8-e1a88aafeccc',
-          type: 'text',
+          type: 'TEXT',
           text:
             "Hanks' second and current wife, Rita Wilson, was raised a member of the Greek Orthodox Church and Hanks has taken on her religion.",
           sourceUrl: null,
@@ -129,7 +129,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'e4f1198a-7cc4-4c1a-ac5b-c3e796f31a35',
-          type: 'text',
+          type: 'TEXT',
           text:
             "If you would have told me a few years ago that 'don't ask, don't tell' would be repealed and about a billion jobs at General Motors and Chrysler would have been saved because the president was smart enough and strong enough and bold enough to do so, I would have said, 'Wow. That's a good president, I think I'll vote for him again.'",
           sourceUrl:
@@ -139,7 +139,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'e6a8b0ba-4721-47c0-b3db-56a2eafa0db6',
-          type: 'text',
+          type: 'TEXT',
           text: 'Politics is just like a box of chocolates…',
           sourceUrl: null,
           sourceTitle: null,
@@ -147,7 +147,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'e916d67c-fdb1-42de-8c8e-5a23bcdff1b9',
-          type: 'text',
+          type: 'TEXT',
           text:
             "He doesn't seem to acknowledge the billions upon billions of taxpayer dollars that were funneled to some of the country's richest men during that bailout, but hey, that's what the PR machine is all about.",
           sourceUrl: null,
@@ -156,7 +156,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'f20b575f-46c2-43f6-a610-919efdce145e',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -164,7 +164,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'fc03f967-414f-4384-a4ee-287f2e7c9592',
-          type: 'text',
+          type: 'TEXT',
           text:
             'However, he quickly rescinded his statement but fought fire with fire, contributing his star power to raising over $44 million to defeat proposition 8–which passed anyway.',
           sourceUrl:
@@ -174,7 +174,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '01d17400-b483-4548-b7db-9f2d3a9db5ab',
-          type: 'text',
+          type: 'TEXT',
           text:
             ' Hanks has said that his greatest motivation for being a church-goer is to come in contact with the great unanswered questions mankind has always asked, questions that, for the most part, only religion attempts to answer.',
           sourceUrl:
@@ -184,7 +184,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '2fa315c4-80d3-403d-8fe6-8551a0577dd4',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -192,7 +192,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'c2f0a449-b1c7-4326-9724-9bbc96cbd965',
-          type: 'quote',
+          type: 'QUOTE',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -200,7 +200,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '6fe7210a-20cd-4994-bb07-18a5c48aafe6',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -208,7 +208,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '32caca6a-2379-4c9c-9c9e-7d00254fe646',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -216,7 +216,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '7bbc711c-174e-48fc-8e42-eac3dbdc71a6',
-          type: 'heading',
+          type: 'HEADING',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -224,7 +224,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '2e5cf554-71bc-42bd-802d-411bfef15068',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -232,7 +232,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '8336dd0f-76e7-45df-b2cf-41a4eb617a46',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -240,7 +240,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: 'd41ccdfb-4107-4667-a521-321ab282f6ad',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -248,7 +248,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '617f0454-e586-4631-baac-44c2a6889593',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -256,7 +256,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '0e2fc2cd-40ca-4e0f-a1ee-c4675fbae77c',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -264,7 +264,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '4b37b4f8-95dd-4924-903b-8e0a76824f23',
-          type: 'quote',
+          type: 'QUOTE',
           text: null,
           sourceUrl: null,
           sourceTitle: null,
@@ -272,7 +272,7 @@ export const notablePersonWithEditorialSummaryQueryResponse: NotablePersonQuery 
         },
         {
           id: '2ce08d61-2758-4bca-be15-d4f2cd2079ef',
-          type: 'paragraph',
+          type: 'PARAGRAPH',
           text: null,
           sourceUrl: null,
           sourceTitle: null,


### PR DESCRIPTION
I've updated the data in the database to use uppercase types for `EditorialSummaryNodeType`. I've also invalidate the API cache to avoid any problems with outdated queries.