### PR TITLE
Default to dark theme if system-wide dark mode is enabled

### DIFF
--- a/src/app/store/createConfiguredStore.ts
+++ b/src/app/store/createConfiguredStore.ts
@@ -126,7 +126,7 @@ const defaultInitialState: StoreState = {
   fbSdkAuthState: {
     state: 'initializing',
   },
-  theme: 'light',
+  theme: matchMedia('(prefers-dark-interface)').matches ? 'dark' : 'light',
 };
 
 const defaultEpicDependencies: EpicDependencies = {


### PR DESCRIPTION
WebKit has recently added support for detecting whether system-wide dark mode is enabled via [the new `prefers-dark-interface` media query](https://mobile.twitter.com/Keithamus/status/1007557906378706944?s=17). This is only available on Safari on macOS Mojave currently. I don't have a macOS device to test this but it should not break anything.